### PR TITLE
Update jbpm-persistence-jpa - JpaProcessPersistenceContext to make visible constructor from parent class 

### DIFF
--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/JpaProcessPersistenceContext.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/JpaProcessPersistenceContext.java
@@ -17,6 +17,10 @@ public class JpaProcessPersistenceContext extends JpaPersistenceContext
     public JpaProcessPersistenceContext(EntityManager em) {
         super( em );
     }
+    
+    public JpaProcessPersistenceContext(EntityManager em, boolean isJTA) {
+        super( em, isJTA );
+    }
 
     public void persist(ProcessInstanceInfo processInstanceInfo) {
         getEntityManager().persist( processInstanceInfo );


### PR DESCRIPTION
Adding another constructor for no-JTA environments. In other words making parent class constructor that takes isJTA parameter visible.