### PR TITLE
WorkItemHandler proper evaluation of parameter expression to object

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/marshalling/impl/AbstractProtobufProcessInstanceMarshaller.java
+++ b/jbpm-flow/src/main/java/org/jbpm/marshalling/impl/AbstractProtobufProcessInstanceMarshaller.java
@@ -356,7 +356,7 @@ public abstract class AbstractProtobufProcessInstanceMarshaller
             ExtensionRegistry registry = PersisterHelper.buildRegistry( context, null ); 
             Header _header;
             try {
-                _header = PersisterHelper.readFromStreamWithHeader( context, registry );
+                _header = PersisterHelper.readFromStreamWithHeaderPreloaded( context, registry );
             } catch ( ClassNotFoundException e ) {
                 // Java 5 does not accept [new IOException(String, Throwable)]
                 IOException ioe =  new IOException( "Error deserializing process instance." );

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/utils/ContentMarshallerHelper.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/task/utils/ContentMarshallerHelper.java
@@ -107,7 +107,7 @@ public class ContentMarshallerHelper {
                 context.classLoader = ContentMarshallerHelper.class.getClassLoader();
             }
             ExtensionRegistry registry = PersisterHelper.buildRegistry( context, null ); 
-            Header _header = PersisterHelper.readFromStreamWithHeader(context, registry);
+            Header _header = PersisterHelper.readFromStreamWithHeaderPreloaded(context, registry);
             Variable parseFrom = JBPMMessages.Variable.parseFrom(_header.getPayload(), registry);
             Object value = ProtobufProcessMarshaller.unmarshallVariableValue(context, parseFrom);
             

--- a/jbpm-human-task/jbpm-human-task-services/src/main/java/org/jbpm/task/utils/ContentMarshallerHelper.java
+++ b/jbpm-human-task/jbpm-human-task-services/src/main/java/org/jbpm/task/utils/ContentMarshallerHelper.java
@@ -90,7 +90,7 @@ public class ContentMarshallerHelper {
                 context.classLoader = ContentMarshallerHelper.class.getClassLoader();
             }
             ExtensionRegistry registry = PersisterHelper.buildRegistry(context, null);
-            Header _header = PersisterHelper.readFromStreamWithHeader(context, registry);
+            Header _header = PersisterHelper.readFromStreamWithHeaderPreloaded(context, registry);
             Variable parseFrom = JBPMMessages.Variable.parseFrom(_header.getPayload(), registry);
             Object value = ProtobufProcessMarshaller.unmarshallVariableValue(context, parseFrom);
 


### PR DESCRIPTION
This is a fix for the problem I described at:

https://community.jboss.org/thread/222708?tstart=0

Basically the issue is that, when an expression resolves to a single arbitrary object, this object is converted to String before being handled to the work item handler. AFAICT this was done because you can have multiple expressions, such as '#{name} - #{description}'. What I've done is, iff there is one expression, the evaluated value is passed directly to the work item handler.

Please notice that I have no idea if this is correct, but all the tests have passed.

BTW in a separate commit I had to change some method calls to drools which were failing to compile, since apparently the method name has changed.