### PR TITLE
Do not allow to create correlation key with empty content

### DIFF
--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/correlation/JPACorrelationKeyFactory.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/correlation/JPACorrelationKeyFactory.java
@@ -23,18 +23,26 @@ import org.kie.internal.process.CorrelationKeyFactory;
 public class JPACorrelationKeyFactory implements CorrelationKeyFactory {
 
     public CorrelationKey newCorrelationKey(String businessKey) {
+        if (businessKey.isEmpty()) {
+            throw new IllegalArgumentException("businessKey cannot be empty");
+        }
+
         CorrelationKeyInfo correlationKey = new CorrelationKeyInfo();
         correlationKey.addProperty(new CorrelationPropertyInfo(null, businessKey));
-        
+
         return correlationKey;
     }
-    
+
     public CorrelationKey newCorrelationKey(List<String> properties) {
+        if (properties.isEmpty()) {
+            throw new IllegalArgumentException("properties cannot be empty");
+        }
+
         CorrelationKeyInfo correlationKey = new CorrelationKeyInfo();
         for (String businessKey : properties) {
             correlationKey.addProperty(new CorrelationPropertyInfo(null, businessKey));
         }
-        
+
         return correlationKey;
     }
 }


### PR DESCRIPTION
I was writing some tests for correlation keys when I realized it is not so easy to find out that you are accidently passing an empty business key to your correlation key instance. I was getting exceptions like this:

java.lang.NullPointerException: null
	at java.util.ArrayList.<init>(ArrayList.java:164)
	at org.jbpm.persistence.correlation.CorrelationKeyInfo.getProperties(CorrelationKeyInfo.java:61)
	at org.jbpm.persistence.JpaProcessPersistenceContext.getProcessInstanceByCorrelationKey(JpaProcessPersistenceContext.java:122)
	at org.jbpm.persistence.processinstance.JPAProcessInstanceManager.getProcessInstance(JPAProcessInstanceManager.java:208)
	at org.jbpm.process.instance.ProcessRuntimeImpl.getProcessInstance(ProcessRuntimeImpl.java:238)
	at org.drools.core.impl.StatefulKnowledgeSessionImpl.getProcessInstance(StatefulKnowledgeSessionImpl.java:1938)
	at org.drools.core.command.runtime.process.GetProcessInstanceByCorrelationKeyCommand.execute(GetProcessInstanceByCorrelationKeyCommand.java:60)
	at org.drools.core.command.runtime.process.GetProcessInstanceByCorrelationKeyCommand.execute(GetProcessInstanceByCorrelationKeyCommand.java:33)
	at org.drools.core.command.impl.DefaultCommandService.execute(DefaultCommandService.java:36)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:41)
	at org.drools.persistence.SingleSessionCommandService$TransactionInterceptor.execute(SingleSessionCommandService.java:548)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:41)
	at org.drools.persistence.jpa.OptimisticLockRetryInterceptor.execute(OptimisticLockRetryInterceptor.java:73)
	at org.drools.core.command.impl.AbstractInterceptor.executeNext(AbstractInterceptor.java:41)
	at org.drools.persistence.jta.TransactionLockInterceptor.execute(TransactionLockInterceptor.java:72)
	at org.drools.persistence.SingleSessionCommandService.execute(SingleSessionCommandService.java:358)
	at org.drools.core.command.impl.CommandBasedStatefulKnowledgeSession.getProcessInstance(CommandBasedStatefulKnowledgeSession.java:543)
	at com.bpms.functional.CorrelationKeyTest.testEmptyMultiValuedKey(CorrelationKeyTest.java:112)

And also this exception is thrown at the time you are using the key and not when you are creating it. So I have decided to add a check for emptiness at the level of CorrelationKeyFactory. I think it is the best solution not to allow users to create a correlation key with an empty content.