### PR TITLE
Fix parent for jbpm-executor-ejb

### DIFF
--- a/jbpm-services/jbpm-services-ejb/jbpm-executor-ejb/pom.xml
+++ b/jbpm-services/jbpm-services-ejb/jbpm-executor-ejb/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.jbpm</groupId>
-    <artifactId>jbpm-services</artifactId>
+    <artifactId>jbpm-services-ejb</artifactId>
     <version>6.3.0-SNAPSHOT</version>
   </parent>
   <artifactId>jbpm-executor-ejb</artifactId>


### PR DESCRIPTION
jbpm-executor-ejb references jbpm-services as it's parent, skipping one level in the hierarchy. This pull request fixes that.
(Discovered this due to master not building for me on my local machine.)