### PR TITLE
Release resources in case of exception thrown in tearDown method

### DIFF
--- a/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
@@ -211,29 +211,31 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
 
     @After
     public void tearDown() throws Exception {
-    	clearCustomRegistry();
-        disposeRuntimeManager();
-        clearHistory();
-        if (setupDataSource) {
-            if (emf != null) {
-                emf.close();
-                emf = null;
-               	EntityManagerFactoryManager.get().clear();
-
-            }
-            if (ds != null) {
-                ds.close();
-                ds = null;
-            }
-            try {
-                InitialContext context = new InitialContext();
-                UserTransaction ut = (UserTransaction) context.lookup( JtaTransactionManager.DEFAULT_USER_TRANSACTION_NAME );
-                if( ut.getStatus() != Status.STATUS_NO_TRANSACTION ) {
-                    ut.setRollbackOnly();
-                    ut.rollback();
+        try {
+            clearCustomRegistry();
+            disposeRuntimeManager();
+            clearHistory();
+        } finally {
+            if (setupDataSource) {
+                if (emf != null) {
+                    emf.close();
+                    emf = null;
+                    EntityManagerFactoryManager.get().clear();
                 }
-            } catch( Exception e ) {
-                // do nothing
+                if (ds != null) {
+                    ds.close();
+                    ds = null;
+                }
+                try {
+                    InitialContext context = new InitialContext();
+                    UserTransaction ut = (UserTransaction) context.lookup( JtaTransactionManager.DEFAULT_USER_TRANSACTION_NAME );
+                    if( ut.getStatus() != Status.STATUS_NO_TRANSACTION ) {
+                        ut.setRollbackOnly();
+                        ut.rollback();
+                    }
+                } catch( Exception e ) {
+                    // do nothing
+                }
             }
         }
     }


### PR DESCRIPTION
If an exception is thrown in tearDown() method of JbpmJUnitBaseTestCase, the data source is not closed properly. This influences other tests run in the same batch and they fail with the following exception:

Caused by: java.lang.IllegalStateException: A resource with uniqueName 'jdbc/jbpm-ds' has already been registered. Cannot register XAResourceProducer 'a PoolingDataSource containing an XAPool of resource jdbc/jbpm-ds with 5 connection(s) (5 still available)'.

So I've put cleaning methods to try block and resources are released in its finally block. This is just a simple fix. If you think anything else needs to be fixed regarding this issue, just let me know and I'll push another commit.