### PR TITLE
Add more tests for LDAPUserGroupCallbackImpl and LDAPUserInfoImpl

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPBaseTest.java
@@ -26,6 +26,18 @@ import org.junit.Before;
 
 public abstract class LDAPBaseTest {
 
+    public enum SearchScope {
+
+        OBJECT_SCOPE, ONELEVEL_SCOPE, SUBTREE_SCOPE
+
+    }
+
+    public enum Configuration {
+
+        CUSTOM, DEFAULT, SYSTEM
+
+    }
+
     private InMemoryDirectoryServer server;
 
     @Before

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserGroupCallbackImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserGroupCallbackImplTest.java
@@ -1,117 +1,336 @@
 package org.jbpm.services.task.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import javax.naming.Context;
 import java.util.List;
 import java.util.Properties;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.After;
 import org.junit.Test;
 import org.kie.api.task.UserGroupCallback;
 
 public class LDAPUserGroupCallbackImplTest extends LDAPBaseTest {
 
+    @After
+    public void clearSystemProperties() {
+        System.clearProperty("jbpm.usergroup.callback.properties");
+    }
+
     @Test
     public void testUserExists() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_ROLES_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_ROLES_FILTER, "(member={0})");
-
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(properties);
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.CUSTOM);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
 
         boolean userExists = ldapUserGroupCallback.existsUser("john");
-        assertTrue(userExists);
+        Assertions.assertThat(userExists).isTrue();
     }
 
     @Test
     public void testGroupExists() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.CUSTOM);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        boolean groupExists = ldapUserGroupCallback.existsGroup("manager");
+        Assertions.assertThat(groupExists).isTrue();
+    }
+
+    @Test
+    public void testGroupsForUser() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.CUSTOM);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        List<String> userGroups = ldapUserGroupCallback.getGroupsForUser("john", null, null);
+        Assertions.assertThat(userGroups).hasSize(1);
+    }
+
+    @Test
+    public void testUserExistsDefaultProperties() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.DEFAULT);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        boolean userExists = ldapUserGroupCallback.existsUser("john");
+        Assertions.assertThat(userExists).isTrue();
+    }
+
+    @Test
+    public void testGroupExistsDefaultProperties() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.DEFAULT);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        boolean groupExists = ldapUserGroupCallback.existsGroup("manager");
+        Assertions.assertThat(groupExists).isTrue();
+    }
+
+    @Test
+    public void testGroupsForUserDefaultProperties() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.DEFAULT);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        List<String> userGroups = ldapUserGroupCallback.getGroupsForUser("john", null, null);
+        Assertions.assertThat(userGroups).hasSize(1);
+    }
+
+    @Test
+    public void testUserExistsSystemProperties() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.SYSTEM);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        boolean userExists = ldapUserGroupCallback.existsUser("john");
+        Assertions.assertThat(userExists).isTrue();
+    }
+
+    @Test
+    public void testGroupExistsSystemProperties() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.SYSTEM);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        boolean groupExists = ldapUserGroupCallback.existsGroup("manager");
+        Assertions.assertThat(groupExists).isTrue();
+    }
+
+    @Test
+    public void testGroupsForUserSystemProperties() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallback(Configuration.SYSTEM);
+        Assertions.assertThat(ldapUserGroupCallback).isNotNull();
+
+        List<String> userGroups = ldapUserGroupCallback.getGroupsForUser("john", null, null);
+        Assertions.assertThat(userGroups).hasSize(1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateCallbackFromNullProperties() {
+        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateCallbackWithoutRequiredProperties() {
+        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(new Properties());
+    }
+
+    @Test
+    public void testUsersObjectScopePeopleContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.OBJECT_SCOPE,
+                "ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersObjectScopeJohnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.OBJECT_SCOPE,
+                "uid=john,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, true, false, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopeBaseDnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.ONELEVEL_SCOPE,
+                "dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopePeopleContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.ONELEVEL_SCOPE,
+                "ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, true, true, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopeJohnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.ONELEVEL_SCOPE,
+                "uid=john,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopeEngContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.ONELEVEL_SCOPE,
+                "ou=ENG,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, false, false, true, false);
+    }
+
+    @Test
+    public void testUsersSubtreeScopeBaseDnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.SUBTREE_SCOPE,
+                "dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, true, true, true, true);
+    }
+
+    @Test
+    public void testUsersSubtreeScopePeopleContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.SUBTREE_SCOPE,
+                "ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, true, true, true, true);
+    }
+
+    @Test
+    public void testUsersSubtreeScopeJohnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.SUBTREE_SCOPE,
+                "uid=john,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, true, false, false, false);
+    }
+
+    @Test
+    public void testUsersSubtreeScopeEngContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithUserCtx(SearchScope.SUBTREE_SCOPE,
+                "ou=ENG,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserGroupCallback, false, false, true, true);
+    }
+
+    @Test
+    public void testGroupsObjectScopeRolesContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.OBJECT_SCOPE,
+                "ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsObjectScopeManagerContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.OBJECT_SCOPE,
+                "cn=manager,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, true, false, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeBaseDnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.ONELEVEL_SCOPE,
+                "dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeRolesContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.ONELEVEL_SCOPE,
+                "ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, true, true, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeManagerContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.ONELEVEL_SCOPE,
+                "cn=manager,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeEngContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.ONELEVEL_SCOPE,
+                "ou=ENG,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, false, false, true, false);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeBaseDnContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.SUBTREE_SCOPE,
+                "dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, true, true, true, true);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeRolesContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.SUBTREE_SCOPE,
+                "ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, true, true, true, true);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeManagerContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.SUBTREE_SCOPE,
+                "cn=manager,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, true, false, false, false);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeEngContext() {
+        UserGroupCallback ldapUserGroupCallback = createLdapUserGroupCallbackWithRoleCtx(SearchScope.SUBTREE_SCOPE,
+                "ou=ENG,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserGroupCallback, false, false, true, true);
+    }
+
+    @Test
+    public void testDefaultScope() {
+        Properties properties = createUserGroupCallbackProperties();
+        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(properties);
+
+        assertUsers(ldapUserGroupCallback, true, true, false, false);
+        assertGroups(ldapUserGroupCallback, true, true, false, false);
+    }
+
+    @Test
+    public void testInvalidScope() {
+        Properties properties = createUserGroupCallbackProperties();
+        properties.setProperty(LDAPUserGroupCallbackImpl.SEARCH_SCOPE, "abc");
+        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(properties);
+
+        assertUsers(ldapUserGroupCallback, true, true, false, false);
+        assertGroups(ldapUserGroupCallback, true, true, false, false);
+    }
+
+    private Properties createUserGroupCallbackProperties() {
         Properties properties = new Properties();
         properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
         properties.setProperty(LDAPUserGroupCallbackImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_ROLES_CTX, "ou=Roles,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserGroupCallbackImpl.USER_FILTER, "(uid={0})");
         properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_FILTER, "(cn={0})");
         properties.setProperty(LDAPUserGroupCallbackImpl.USER_ROLES_FILTER, "(member={0})");
-
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(properties);
-
-        boolean userExists = ldapUserGroupCallback.existsGroup("manager");
-        assertTrue(userExists);
+        return properties;
     }
 
-    @Test
-    public void testUserGroup() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_ROLES_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserGroupCallbackImpl.USER_ROLES_FILTER, "(member={0})");
-
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(properties);
-
-        List<String> userGroups = ldapUserGroupCallback.getGroupsForUser("john", null, null);
-        assertEquals(3, userGroups.size());
+    private Properties createUserGroupCallbackProperties(SearchScope searchScope) {
+        Properties properties = createUserGroupCallbackProperties();
+        properties.setProperty(LDAPUserGroupCallbackImpl.SEARCH_SCOPE, searchScope.name());
+        return properties;
     }
 
-    @Test
-    public void testDefaultPropsUserExists() {
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(true);
-
-        boolean userExists = ldapUserGroupCallback.existsUser("john");
-        assertTrue(userExists);
+    private UserGroupCallback createLdapUserGroupCallback(Configuration config) {
+        switch (config) {
+            case CUSTOM:
+                return new LDAPUserGroupCallbackImpl(createUserGroupCallbackProperties());
+            case SYSTEM:
+                System.setProperty("jbpm.usergroup.callback.properties", "/jbpm.usergroup.callback.properties");
+            case DEFAULT:
+                return new LDAPUserGroupCallbackImpl(true);
+            default:
+                throw new IllegalArgumentException("unknown config type");
+        }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testValidationErrorUserExists() {
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(new Properties());
-
-        boolean userExists = ldapUserGroupCallback.existsUser("john");
-        assertTrue(userExists);
+    private UserGroupCallback createLdapUserGroupCallbackWithUserCtx(SearchScope searchScope, String userCtx) {
+        Properties properties = createUserGroupCallbackProperties(searchScope);
+        properties.setProperty(LDAPUserGroupCallbackImpl.USER_CTX, userCtx);
+        return new LDAPUserGroupCallbackImpl(properties);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testValidationErrorGroupExists() {
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(new Properties());
-
-        boolean userExists = ldapUserGroupCallback.existsGroup("john");
-        assertTrue(userExists);
+    private UserGroupCallback createLdapUserGroupCallbackWithRoleCtx(SearchScope searchScope, String roleCtx) {
+        Properties properties = createUserGroupCallbackProperties(searchScope);
+        properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_CTX, roleCtx);
+        return new LDAPUserGroupCallbackImpl(properties);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testValidationErrorUserGroup() {
-        Properties properties = new Properties();
+    private void assertUsers(UserGroupCallback userGroupCallback, boolean john, boolean mary, boolean peter,
+            boolean mike) {
+        Assertions.assertThat(userGroupCallback).isNotNull();
 
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(properties);
-
-        List<String> userGroups = ldapUserGroupCallback.getGroupsForUser("john", null, null);
-        assertEquals(1, userGroups.size());
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(userGroupCallback.existsUser("john")).as("john").isEqualTo(john);
+        assertions.assertThat(userGroupCallback.existsUser("mary")).as("mary").isEqualTo(mary);
+        assertions.assertThat(userGroupCallback.existsUser("peter")).as("peter").isEqualTo(peter);
+        assertions.assertThat(userGroupCallback.existsUser("mike")).as("mike").isEqualTo(mike);
+        assertions.assertAll();
     }
 
-    @Test
-    public void testCreateCallbackFromProperties() {
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(true);
+    private void assertGroups(UserGroupCallback userGroupCallback, boolean manager, boolean user, boolean analyst,
+            boolean developer) {
+        Assertions.assertThat(userGroupCallback).isNotNull();
 
-        assertNotNull(ldapUserGroupCallback);
-    }
-
-    @Test
-    public void testCreateCallbackFromCustomProperties() {
-        System.setProperty("jbpm.usergroup.callback.properties", "/jbpm.usergroup.callback.properties");
-        UserGroupCallback ldapUserGroupCallback = new LDAPUserGroupCallbackImpl(true);
-
-        assertNotNull(ldapUserGroupCallback);
-        System.clearProperty("jbpm.usergroup.callback.properties");
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(userGroupCallback.existsGroup("manager")).as("manager").isEqualTo(manager);
+        assertions.assertThat(userGroupCallback.existsGroup("user")).as("user").isEqualTo(user);
+        assertions.assertThat(userGroupCallback.existsGroup("analyst")).as("analyst").isEqualTo(analyst);
+        assertions.assertThat(userGroupCallback.existsGroup("developer")).as("developer").isEqualTo(developer);
+        assertions.assertAll();
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserInfoImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserInfoImplTest.java
@@ -1,191 +1,573 @@
 package org.jbpm.services.task.identity;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.jbpm.services.task.identity.LDAPBaseTest.SearchScope.OBJECT_SCOPE;
+import static org.jbpm.services.task.identity.LDAPBaseTest.SearchScope.ONELEVEL_SCOPE;
+import static org.jbpm.services.task.identity.LDAPBaseTest.SearchScope.SUBTREE_SCOPE;
 
 import javax.naming.Context;
-import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Properties;
 
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.task.model.Group;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.User;
 import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.UserInfo;
-import org.kie.internal.task.api.model.InternalOrganizationalEntity;
 
 public class LDAPUserInfoImplTest extends LDAPBaseTest {
 
-    @Test
-    public void testGetEmailForUserEntity() {
+    private static final User JOHN = TaskModelProvider.getFactory().newUser("john");
+    private static final User JOHN_DN = TaskModelProvider.getFactory().newUser("uid=john,ou=People,dc=jbpm,dc=org");
+    private static final User MARY = TaskModelProvider.getFactory().newUser("mary");
+    private static final User MARY_DN = TaskModelProvider.getFactory().newUser("uid=mary,ou=People,dc=jbpm,dc=org");
+    private static final User PETER = TaskModelProvider.getFactory().newUser("peter");
+    private static final User MIKE = TaskModelProvider.getFactory().newUser("mike");
+
+    private static final Group MANAGER = TaskModelProvider.getFactory().newGroup("manager");
+    private static final Group MANAGER_DN = TaskModelProvider.getFactory().newGroup("cn=manager,ou=Roles,dc=jbpm,dc=org");
+    private static final Group USER = TaskModelProvider.getFactory().newGroup("user");
+    private static final Group USER_DN = TaskModelProvider.getFactory().newGroup("cn=user,ou=Roles,dc=jbpm,dc=org");
+    private static final Group ANALYST = TaskModelProvider.getFactory().newGroup("analyst");
+    private static final Group DEVELOPER = TaskModelProvider.getFactory().newGroup("developer");
+
+    private Properties createUserInfoProperties() {
         Properties properties = new Properties();
         properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
         properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
         properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        User user = TaskModelProvider.getFactory().newUser();
-        ((InternalOrganizationalEntity) user).setId("john");
-        String email = ldapUserInfo.getEmailForEntity(user);
-        assertNotNull(email);
-        assertEquals("john@jbpm.org", email);
+        return properties;
     }
 
-    @Test
-    public void testGetEmailForGroupEntity() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserInfoImpl.EMAIL_ATTR_ID, "ou");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        Group group = TaskModelProvider.getFactory().newGroup();
-        ((InternalOrganizationalEntity) group).setId("manager");
-        String email = ldapUserInfo.getEmailForEntity(group);
-        assertNotNull(email);
-        assertEquals("managers@jbpm.org", email);
+    private Properties createUserInfoProperties(SearchScope searchScope) {
+        Properties properties = createUserInfoProperties();
+        properties.setProperty(LDAPUserInfoImpl.SEARCH_SCOPE, searchScope.name());
+        return properties;
     }
 
-    @Test
-    public void testGetEmailForUserEntityAsDN() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        User user = TaskModelProvider.getFactory().newUser();
-        ((InternalOrganizationalEntity) user).setId("uid=john,ou=People,dc=jbpm,dc=org");
-        String email = ldapUserInfo.getEmailForEntity(user);
-        assertNotNull(email);
-        assertEquals("john@jbpm.org", email);
-    }
-
-    @Test
-    public void testGetEmailForGroupEntityAsDN() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
-        properties.setProperty(LDAPUserInfoImpl.EMAIL_ATTR_ID, "ou");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        Group group = TaskModelProvider.getFactory().newGroup();
-        ((InternalOrganizationalEntity) group).setId("cn=manager,ou=Roles,dc=jbpm,dc=org");
-        String email = ldapUserInfo.getEmailForEntity(group);
-        assertNotNull(email);
-        assertEquals("managers@jbpm.org", email);
-    }
-
-    @Test
-    public void testGetGroupMembers() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserInfoImpl.MEMBER_ATTR_ID, "member");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-
-        Group group = TaskModelProvider.getFactory().newGroup();
-        ((InternalOrganizationalEntity) group).setId("manager");
-        Iterator<OrganizationalEntity> members = ldapUserInfo.getMembersForGroup(group);
-        assertNotNull(members);
-        List<OrganizationalEntity> orgMembers = new ArrayList<OrganizationalEntity>();
-
-        while (members.hasNext()) {
-            OrganizationalEntity organizationalEntity = (OrganizationalEntity) members
-                    .next();
-            orgMembers.add(organizationalEntity);
+    private void testGetDisplayName(OrganizationalEntity entity, String expectedName, boolean customAttribute) {
+        Properties properties = createUserInfoProperties();
+        if (customAttribute) {
+            properties.setProperty(LDAPUserInfoImpl.NAME_ATTR_ID, "name");
         }
-        assertEquals(4, orgMembers.size());
-
+        if (entity.getId().startsWith("uid=") || entity.getId().startsWith("cn=")) {
+            properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
+        }
+        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
+        String name = ldapUserInfo.getDisplayName(entity);
+        Assertions.assertThat(name).isNotNull();
+        Assertions.assertThat(name).isEqualTo(expectedName);
     }
 
     @Test
-    public void testGetNameForUserEntity() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        User user = TaskModelProvider.getFactory().newUser();
-        ((InternalOrganizationalEntity) user).setId("john");
-        String email = ldapUserInfo.getDisplayName(user);
-        assertNotNull(email);
-        assertEquals("John Doe", email);
+    public void testGetDisplayNameForUserByDefaultAttribute() {
+        testGetDisplayName(JOHN, "John Doe", false);
     }
 
     @Test
-    public void testGetNameForGroupEntity() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-        properties.setProperty(LDAPUserInfoImpl.NAME_ATTR_ID, "description");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        Group group = TaskModelProvider.getFactory().newGroup();
-        ((InternalOrganizationalEntity) group).setId("manager");
-        String email = ldapUserInfo.getDisplayName(group);
-        assertNotNull(email);
-        assertEquals("Manager group", email);
+    public void testGetDisplayNameForUserDnByDefaultAttribute() {
+        testGetDisplayName(JOHN_DN, "John Doe", false);
     }
 
     @Test
-    public void testGetLangForUserEntity() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
-
-        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-
-        User user = TaskModelProvider.getFactory().newUser();
-        ((InternalOrganizationalEntity) user).setId("john");
-        String email = ldapUserInfo.getLanguageForEntity(user);
-        assertNotNull(email);
-        assertEquals("en-UK", email);
+    public void testGetDisplayNameForUserByCustomAttribute() {
+        testGetDisplayName(MARY, "Mary Snow", true);
     }
 
     @Test
-    public void testGetLangForGroupEntity() {
-        Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
-        properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
-        properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
-        properties.setProperty(LDAPUserInfoImpl.ROLE_FILTER, "(cn={0})");
+    public void testGetDisplayNameForUserDnByCustomAttribute() {
+        testGetDisplayName(MARY_DN, "Mary Snow", true);
+    }
 
+    @Test
+    public void testGetDisplayNameForGroupByDefaultAttribute() {
+        testGetDisplayName(MANAGER, "jBPM manager", false);
+    }
+
+    @Test
+    public void testGetDisplayNameForGroupDnByDefaultAttribute() {
+        testGetDisplayName(MANAGER_DN, "jBPM manager", false);
+    }
+
+    @Test
+    public void testGetDisplayNameForGroupByCustomAttribute() {
+        testGetDisplayName(USER, "jBPM user", true);
+    }
+
+    @Test
+    public void testGetDisplayNameForGroupDnByCustomAttribute() {
+        testGetDisplayName(USER_DN, "jBPM user", true);
+    }
+
+    private void testGetMembersForGroup(boolean emptyGroup, boolean customAttribute, boolean distinguishedName) {
+        Properties properties = createUserInfoProperties();
+        if (customAttribute) {
+            properties.setProperty(LDAPUserInfoImpl.MEMBER_ATTR_ID, "representative");
+        }
+        if (distinguishedName) {
+            properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
+        }
         UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
-        Group group = TaskModelProvider.getFactory().newGroup();
-        ((InternalOrganizationalEntity) group).setId("manager");
-        String email = ldapUserInfo.getLanguageForEntity(group);
-        assertNotNull(email);
-        assertEquals("en-UK", email);
+
+        Group group;
+        if (distinguishedName) {
+            group = emptyGroup ? USER_DN : MANAGER_DN;
+        } else {
+            group = emptyGroup ? USER : MANAGER;
+        }
+        Iterator<OrganizationalEntity> iterator = ldapUserInfo.getMembersForGroup(group);
+
+        if (emptyGroup) {
+            Assertions.assertThat(iterator.hasNext()).isFalse();
+            return;
+        }
+
+        Assertions.assertThat(iterator.hasNext()).isTrue();
+        User user = (User) iterator.next();
+        if (customAttribute) {
+            Assertions.assertThat(user.getId()).isEqualTo(MARY_DN.getId());
+        } else {
+            Assertions.assertThat(user.getId()).isEqualTo(JOHN_DN.getId());
+        }
+        Assertions.assertThat(iterator.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testGetMembersForGroupByDefaultAttribute() {
+        testGetMembersForGroup(false, false, false);
+    }
+
+    @Ignore
+    @Test
+    public void testGetMembersForGroupDnByDefaultAttribute() {
+        testGetMembersForGroup(false, false, true);
+    }
+
+    @Test
+    public void testGetMembersForGroupByCustomAttribute() {
+        testGetMembersForGroup(false, true, false);
+    }
+
+    @Ignore
+    @Test
+    public void testGetMembersForGroupDnByCustomAttribute() {
+        testGetMembersForGroup(false, true, true);
+    }
+
+    @Test
+    public void testGetMembersForEmptyGroupByDefaultAttribute() {
+        testGetMembersForGroup(true, false, false);
+    }
+
+    @Test
+    public void testGetMembersForEmptyGroupByCustomAttribute() {
+        testGetMembersForGroup(true, true, false);
+    }
+
+    private void testHasEmail(Group group, boolean hasEmail, boolean customAttribute) {
+        Properties properties = createUserInfoProperties();
+        if (customAttribute) {
+            properties.setProperty(LDAPUserInfoImpl.EMAIL_ATTR_ID, "email");
+        }
+        if (group.getId().startsWith("cn=")) {
+            properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
+        }
+        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
+
+        Assertions.assertThat(ldapUserInfo.hasEmail(group)).isEqualTo(hasEmail);
+    }
+
+    @Test
+    public void testHasExistingEmailByDefaultAttribute() {
+        testHasEmail(MANAGER, true, false);
+    }
+
+    @Ignore
+    @Test
+    public void testHasExistingEmailDnByDefaultAttribute() {
+        testHasEmail(MANAGER_DN, true, false);
+    }
+
+    @Test
+    public void testHasExistingEmailByCustomAttribute() {
+        testHasEmail(USER, true, true);
+    }
+
+    @Ignore
+    @Test
+    public void testHasExistingEmailDnByCustomAttribute() {
+        testHasEmail(USER_DN, true, true);
+    }
+
+    @Test
+    public void testHasNonExistingEmailByDefaultAttribute() {
+        testHasEmail(USER, false, false);
+    }
+
+    @Test
+    public void testHasNonExistingEmailByCustomAttribute() {
+        testHasEmail(MANAGER, false, true);
+    }
+
+    private void testGetEmailForEntity(OrganizationalEntity entity, String email, boolean customAttribute) {
+        Properties properties = createUserInfoProperties();
+        if (customAttribute) {
+            properties.setProperty(LDAPUserInfoImpl.EMAIL_ATTR_ID, "email");
+        }
+        if (entity.getId().startsWith("uid=") || entity.getId().startsWith("cn=")) {
+            properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
+        }
+        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
+
+        Assertions.assertThat(ldapUserInfo.getEmailForEntity(entity)).isEqualTo(email);
+    }
+
+    @Test
+    public void testGetExistingEmailForUserByDefaultAttribute() {
+        testGetEmailForEntity(JOHN, "johndoe@jbpm.org", false);
+    }
+
+    @Test
+    public void testGetExistingEmailForUserDnByDefaultAttribute() {
+        testGetEmailForEntity(JOHN_DN, "johndoe@jbpm.org", false);
+    }
+
+    @Test
+    public void testGetExistingEmailForUserByCustomAttribute() {
+        testGetEmailForEntity(MARY, "marysnow@jbpm.org", true);
+    }
+
+    @Test
+    public void testGetExistingEmailForUserDnByCustomAttribute() {
+        testGetEmailForEntity(MARY_DN, "marysnow@jbpm.org", true);
+    }
+
+    @Test
+    public void testGetNonExistingEmailForUserByDefaultAttribute() {
+        testGetEmailForEntity(MARY, null, false);
+    }
+
+    @Test
+    public void testGetNonExistingEmailForUserByCustomAttribute() {
+        testGetEmailForEntity(JOHN, null, true);
+    }
+
+    @Test
+    public void testGetExistingEmailForGroupByDefaultAttribute() {
+        testGetEmailForEntity(MANAGER, "manager@jbpm.org", false);
+    }
+
+    @Test
+    public void testGetExistingEmailForGroupDnByDefaultAttribute() {
+        testGetEmailForEntity(MANAGER_DN, "manager@jbpm.org", false);
+    }
+
+    @Test
+    public void testGetExistingEmailForGroupByCustomAttribute() {
+        testGetEmailForEntity(USER, "user@jbpm.org", true);
+    }
+
+    @Test
+    public void testGetExistingEmailForGroupDnByCustomAttribute() {
+        testGetEmailForEntity(USER_DN, "user@jbpm.org", true);
+    }
+
+    @Test
+    public void testGetNonExistingEmailForGroupByDefaultAttribute() {
+        testGetEmailForEntity(USER, null, false);
+    }
+
+    @Test
+    public void testGetNonExistingEmailForGroupByCustomAttribute() {
+        testGetEmailForEntity(MANAGER, null, true);
+    }
+
+    private void testGetLanguageForEntity(OrganizationalEntity entity, String language, boolean customAttribute) {
+        Properties properties = createUserInfoProperties();
+        if (customAttribute) {
+            properties.setProperty(LDAPUserInfoImpl.LANG_ATTR_ID, "language");
+        }
+        if (entity.getId().startsWith("uid=") || entity.getId().startsWith("cn=")) {
+            properties.setProperty(LDAPUserInfoImpl.IS_ENTITY_ID_DN, "true");
+        }
+        UserInfo ldapUserInfo = new LDAPUserInfoImpl(properties);
+
+        Assertions.assertThat(ldapUserInfo.getLanguageForEntity(entity)).isEqualTo(language);
+    }
+
+    @Test
+    public void testGetLanguageForUserByDefaultAttribute() {
+        testGetLanguageForEntity(JOHN, "en-US", false);
+    }
+
+    @Test
+    public void testGetLanguageForUserDnByDefaultAttribute() {
+        testGetLanguageForEntity(JOHN_DN, "en-US", false);
+    }
+
+    @Test
+    public void testGetLanguageForUserByCustomAttribute() {
+        testGetLanguageForEntity(MARY, "fr-FR", true);
+    }
+
+    @Test
+    public void testGetLanguageForUserDnByCustomAttribute() {
+        testGetLanguageForEntity(MARY_DN, "fr-FR", true);
+    }
+
+    @Test
+    public void testGetDefaultLanguageForUserByDefaultAttribute() {
+        testGetLanguageForEntity(MARY, "en-UK", false);
+    }
+
+    @Test
+    public void testGetDefaultLanguageForUserByCustomAttribute() {
+        testGetLanguageForEntity(JOHN, "en-UK", true);
+    }
+
+    @Test
+    public void testGetLanguageForGroupByDefaultAttribute() {
+        testGetLanguageForEntity(MANAGER, "en-US", false);
+    }
+
+    @Test
+    public void testGetLanguageForGroupDnByDefaultAttribute() {
+        testGetLanguageForEntity(MANAGER_DN, "en-US", false);
+    }
+
+    @Test
+    public void testGetLanguageForGroupByCustomAttribute() {
+        testGetLanguageForEntity(USER, "fr-FR", true);
+    }
+
+    @Test
+    public void testGetLanguageForGroupDnByCustomAttribute() {
+        testGetLanguageForEntity(USER_DN, "fr-FR", true);
+    }
+
+    @Test
+    public void testGetDefaultLanguageForGroupByDefaultAttribute() {
+        testGetLanguageForEntity(USER, "en-UK", false);
+    }
+
+    @Test
+    public void testGetDefaultLanguageForGroupByCustomAttribute() {
+        testGetLanguageForEntity(MANAGER, "en-UK", true);
+    }
+
+    private UserInfo createLdapUserInfoUid(Properties properties) {
+        properties.setProperty(LDAPUserInfoImpl.NAME_ATTR_ID, "uid");
+        return new LDAPUserInfoImpl(properties);
+    }
+
+    private UserInfo createLdapUserInfoWithUserCtx(SearchScope searchScope, String userCtx) {
+        Properties properties = createUserInfoProperties(searchScope);
+        properties.setProperty(LDAPUserInfoImpl.USER_CTX, userCtx);
+        return createLdapUserInfoUid(properties);
+    }
+
+    private UserInfo createLdapUserInfoCn(Properties properties) {
+        properties.setProperty(LDAPUserInfoImpl.NAME_ATTR_ID, "cn");
+        return new LDAPUserInfoImpl(properties);
+    }
+
+    private UserInfo createLdapUserInfoWithGroupCtx(SearchScope searchScope, String groupCtx) {
+        Properties properties = createUserInfoProperties(searchScope);
+        properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, groupCtx);
+        return createLdapUserInfoCn(properties);
+    }
+
+    private void assertUsers(UserInfo userInfo, boolean john, boolean mary, boolean peter, boolean mike) {
+        Assertions.assertThat(userInfo).isNotNull();
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(userInfo.getDisplayName(JOHN)).as(JOHN.getId()).isEqualTo(john ? JOHN.getId() : null);
+        assertions.assertThat(userInfo.getDisplayName(MARY)).as(MARY.getId()).isEqualTo(mary ? MARY.getId() : null);
+        assertions.assertThat(userInfo.getDisplayName(PETER)).as(PETER.getId()).isEqualTo(peter ? PETER.getId() : null);
+        assertions.assertThat(userInfo.getDisplayName(MIKE)).as(MIKE.getId()).isEqualTo(mike ? MIKE.getId() : null);
+        assertions.assertAll();
+    }
+
+    private void assertGroups(UserInfo userInfo, boolean manager, boolean user, boolean analyst, boolean developer) {
+        Assertions.assertThat(userInfo).isNotNull();
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(userInfo.getDisplayName(MANAGER)).as(MANAGER.getId())
+                .isEqualTo(manager ? MANAGER.getId() : null);
+        assertions.assertThat(userInfo.getDisplayName(USER)).as(USER.getId())
+                .isEqualTo(user ? USER.getId() : null);
+        assertions.assertThat(userInfo.getDisplayName(ANALYST)).as(ANALYST.getId())
+                .isEqualTo(analyst ? ANALYST.getId() : null);
+        assertions.assertThat(userInfo.getDisplayName(DEVELOPER)).as(DEVELOPER.getId())
+                .isEqualTo(developer ? DEVELOPER.getId() : null);
+        assertions.assertAll();
+    }
+
+    @Test
+    public void testUsersObjectScopeBaseDnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(OBJECT_SCOPE, "dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersObjectScopePeopleContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(OBJECT_SCOPE, "ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersObjectScopeJohnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(OBJECT_SCOPE, "uid=john,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, true, false, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopeBaseDnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(ONELEVEL_SCOPE, "dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopePeopleContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(ONELEVEL_SCOPE, "ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, true, true, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopeJohnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(ONELEVEL_SCOPE, "uid=john,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testUsersOneLevelScopeEngContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(ONELEVEL_SCOPE, "ou=ENG,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, false, false, true, false);
+    }
+
+    @Test
+    public void testUsersSubtreeScopeBaseDnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(SUBTREE_SCOPE, "dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, true, true, true, true);
+    }
+
+    @Test
+    public void testUsersSubtreeScopePeopleContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(SUBTREE_SCOPE, "ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, true, true, true, true);
+    }
+
+    @Test
+    public void testUsersSubtreeScopeJohnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(SUBTREE_SCOPE, "uid=john,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, true, false, false, false);
+    }
+
+    @Test
+    public void testUsersSubtreeScopeEngContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithUserCtx(SUBTREE_SCOPE, "ou=ENG,ou=People,dc=jbpm,dc=org");
+        assertUsers(ldapUserInfo, false, false, true, true);
+    }
+
+    @Test
+    public void testGroupsObjectScopeBaseDnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(OBJECT_SCOPE, "dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsObjectScopeRolesContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(OBJECT_SCOPE, "ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsObjectScopeManagerContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(OBJECT_SCOPE, "cn=manager,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, true, false, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeBaseDnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(ONELEVEL_SCOPE, "dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeRolesContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(ONELEVEL_SCOPE, "ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, true, true, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeManagerContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(ONELEVEL_SCOPE, "cn=manager,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, false, false, false, false);
+    }
+
+    @Test
+    public void testGroupsOneLevelScopeEngContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(ONELEVEL_SCOPE, "ou=ENG,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, false, false, true, false);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeBaseDnContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(SUBTREE_SCOPE, "dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, true, true, true, true);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeRolesContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(SUBTREE_SCOPE, "ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, true, true, true, true);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeManagerContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(SUBTREE_SCOPE, "cn=manager,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, true, false, false, false);
+    }
+
+    @Test
+    public void testGroupsSubtreeScopeEngContext() {
+        UserInfo ldapUserInfo = createLdapUserInfoWithGroupCtx(SUBTREE_SCOPE, "ou=ENG,ou=Roles,dc=jbpm,dc=org");
+        assertGroups(ldapUserInfo, false, false, true, true);
+    }
+
+    @Test
+    public void testUsersDefaultScope() {
+        UserInfo ldapUserInfo = createLdapUserInfoUid(createUserInfoProperties());
+        assertUsers(ldapUserInfo, true, true, false, false);
+    }
+
+    @Test
+    public void testGroupsDefaultScope() {
+        UserInfo ldapUserInfo = createLdapUserInfoCn(createUserInfoProperties());
+        assertGroups(ldapUserInfo, true, true, false, false);
+    }
+
+    @Test
+    public void testUsersInvalidScope() {
+        Properties properties = createUserInfoProperties();
+        properties.setProperty(LDAPUserInfoImpl.SEARCH_SCOPE, "xyz");
+        UserInfo ldapUserInfo = createLdapUserInfoUid(properties);
+
+        assertUsers(ldapUserInfo, true, true, false, false);
+    }
+
+    @Test
+    public void testGroupsInvalidScope() {
+        Properties properties = createUserInfoProperties();
+        properties.setProperty(LDAPUserInfoImpl.SEARCH_SCOPE, "xyz");
+        UserInfo ldapUserInfo = createLdapUserInfoCn(properties);
+
+        assertGroups(ldapUserInfo, true, true, false, false);
     }
 
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/test/resources/ldap-config.ldif
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/resources/ldap-config.ldif
@@ -10,89 +10,86 @@ objectclass: top
 objectclass: organizationalUnit
 ou: People
 
-dn: ou=Roles,dc=jbpm,dc=org
-objectclass: top
-objectclass: organizationalUnit
-ou: Roles
-
-dn: uid=krisv,ou=People,dc=jbpm,dc=org
-objectclass: top
-objectclass: uidObject
-objectclass: person
-objectClass: inetOrgPerson
-uid: krisv
-cn: krisv
-sn: KrisV
-displayName: Kris Verlaenen
-mail: krisv@jbpm.org
-userPassword: krisv
-
 dn: uid=john,ou=People,dc=jbpm,dc=org
 objectclass: top
 objectclass: uidObject
 objectclass: person
-objectClass: inetOrgPerson
+objectclass: inetOrgPerson
 uid: john
-cn: john
-sn: John
 displayName: John Doe
-mail: john@jbpm.org
-userPassword: john
+mail: johndoe@jbpm.org
+locale: en-US
 
 dn: uid=mary,ou=People,dc=jbpm,dc=org
 objectclass: top
 objectclass: uidObject
 objectclass: person
-objectClass: inetOrgPerson
 uid: mary
-cn: mary
-sn: Mary
-displayName: Mary Bloody
-mail: mary@jbpm.org
-userPassword: mary
+name: Mary Snow
+email: marysnow@jbpm.org
+language: fr-FR
 
-dn: uid=admin,ou=People,dc=jbpm,dc=org
+dn: ou=ENG,ou=People,dc=jbpm,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: ENG
+
+dn: uid=peter,ou=ENG,ou=People,dc=jbpm,dc=org
 objectclass: top
 objectclass: uidObject
 objectclass: person
-objectClass: inetOrgPerson
-uid: admin
-cn: admin
-sn: Admin
-displayName: Administrator of jBPM
-mail: admin@jbpm.org
-userPassword: admin
+uid: peter
 
+dn: ou=QA,ou=ENG,ou=People,dc=jbpm,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: QA
 
-dn: cn=admin,ou=Roles,dc=jbpm,dc=org
-objectClass: groupOfNames
-objectClass: top
-cn: admin
-description: Admin group
-ou: admins@jbpm.org
-member: uid=krisv,ou=People,dc=jbpm,dc=org
-member: uid=john,ou=People,dc=jbpm,dc=org
-member: uid=mary,ou=People,dc=jbpm,dc=org
-member: uid=admin,ou=People,dc=jbpm,dc=org
+dn: uid=mike,ou=QA,ou=ENG,ou=People,dc=jbpm,dc=org
+objectclass: top
+objectclass: uidObject
+objectclass: person
+uid: mike
+
+dn: ou=Roles,dc=jbpm,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: Roles
 
 dn: cn=manager,ou=Roles,dc=jbpm,dc=org
-objectClass: groupOfNames
-objectClass: top
-cn: manager
-description: Manager group
-ou: managers@jbpm.org
-member: uid=krisv,ou=People,dc=jbpm,dc=org
+objectclass: top
+objectclass: groupOfNames
 member: uid=john,ou=People,dc=jbpm,dc=org
-member: uid=mary,ou=People,dc=jbpm,dc=org
-member: uid=admin,ou=People,dc=jbpm,dc=org
+representative: uid=mary,ou=People,dc=jbpm,dc=org
+cn: manager
+displayName: jBPM manager
+mail: manager@jbpm.org
+locale: en-US
 
 dn: cn=user,ou=Roles,dc=jbpm,dc=org
-objectClass: groupOfNames
-objectClass: top
+objectclass: top
+objectclass: groupOfNames
 cn: user
-description: User group
-ou: users@jbpm.org
-member: uid=krisv,ou=People,dc=jbpm,dc=org
-member: uid=john,ou=People,dc=jbpm,dc=org
-member: uid=mary,ou=People,dc=jbpm,dc=org
-member: uid=admin,ou=People,dc=jbpm,dc=org
+name: jBPM user
+email: user@jbpm.org
+language: fr-FR
+
+dn: ou=ENG,ou=Roles,dc=jbpm,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: ENG
+
+dn: cn=analyst,ou=ENG,ou=Roles,dc=jbpm,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: analyst
+
+dn: ou=RD,ou=ENG,ou=Roles,dc=jbpm,dc=org
+objectclass: top
+objectclass: organizationalUnit
+ou: RD
+
+dn: cn=developer,ou=RD,ou=ENG,ou=Roles,dc=jbpm,dc=org
+objectclass: top
+objectclass: groupOfNames
+cn: developer

--- a/jbpm-human-task/pom.xml
+++ b/jbpm-human-task/pom.xml
@@ -35,6 +35,11 @@
       <artifactId>btm</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>


### PR DESCRIPTION
I have moved some tests from QE test suite that can be used as unit tests for LDAPUserGroupCallbackImpl and LDAPUserInfoImpl. Besides moving the existing tests, I have also added some new test cases for IS_ENTITY_ID_DN=true and it seems that getMembersForGroup and hasEmail from LDAPUserInfoImpl ignore this property and do not work correctly when you pass a group with DN as a parameter. Is this an intended behavior? See 4 ignored tests for more details.