### PR TITLE
GUVNOR-2173 - alternative way to collect reusable processes reference…

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/bpmn2/BPMN2DataServiceImpl.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/bpmn2/BPMN2DataServiceImpl.java
@@ -48,7 +48,6 @@ import org.jbpm.services.api.model.ProcessDefinition;
 import org.jbpm.services.api.model.UserTaskDefinition;
 import org.kie.api.definition.process.Process;
 import org.kie.api.io.ResourceType;
-import org.kie.api.runtime.KieContainer;
 import org.kie.internal.builder.KnowledgeBuilder;
 import org.kie.internal.builder.KnowledgeBuilderError;
 import org.kie.internal.builder.KnowledgeBuilderFactory;
@@ -133,7 +132,7 @@ public class BPMN2DataServiceImpl implements DefinitionService, DeploymentEventL
     }
    
 	@Override
-	public ProcessDefinition buildProcessDefinition(String deploymentId,String bpmn2Content, KieContainer kieContainer, boolean cache)
+	public ProcessDefinition buildProcessDefinition(String deploymentId,String bpmn2Content, ClassLoader classLoader, boolean cache)
 			throws IllegalArgumentException {
 		if (StringUtils.isEmpty(bpmn2Content)) {
             return null;
@@ -153,8 +152,8 @@ public class BPMN2DataServiceImpl implements DefinitionService, DeploymentEventL
 	      
 	        KnowledgeBuilder kbuilder = null;
 	        
-	        if (kieContainer != null && kieContainer.getClassLoader() != null ) { 
-	            KnowledgeBuilderConfigurationImpl pconf = new KnowledgeBuilderConfigurationImpl(kieContainer.getClassLoader());
+	        if (classLoader != null ) { 
+	            KnowledgeBuilderConfigurationImpl pconf = new KnowledgeBuilderConfigurationImpl(classLoader);
 	            kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder(pconf);
 	        } else {
 	            kbuilder = KnowledgeBuilderFactory.newKnowledgeBuilder();
@@ -173,16 +172,12 @@ public class BPMN2DataServiceImpl implements DefinitionService, DeploymentEventL
 	        Process process = pckg.getProcesses().iterator().next();
 	        
 	        ProcessDescRepoHelper helper = MODULE.getRepo().removeProcessDescription(process.getId());
+	        helper.setDefinitionService(this);
 	        ProcessAssetDesc definition = helper.getProcess();
 	        
 	        definition.setAssociatedEntities(helper.getTaskAssignments());
 	        definition.setProcessVariables(helper.getInputs());
 	        definition.setServiceTasks(helper.getServiceTasks());
-	      
-	        if( kieContainer != null && helper.hasUnresolvedReusableSubProcessNames() ) { 
-	           helper.resolveReusableSubProcessNames(kieContainer.getKieBase().getProcesses());
-	        }
-	        definition.setReusableSubProcesses(helper.getReusableSubProcesses());
 	        
 	        // cache the data if requested
 	        if (cache) {
@@ -211,7 +206,8 @@ public class BPMN2DataServiceImpl implements DefinitionService, DeploymentEventL
 	 * This method is used to set the process {@link ProcessDescRepoHelper} instance. 
 	 * @param processHelper
 	 */
-	static void useDataServiceExpressionBuilders(ProcessDescRepoHelper processHelper) { 
+	@SuppressWarnings("rawtypes")
+    static void useDataServiceExpressionBuilders(ProcessDescRepoHelper processHelper) { 
 	    for( int i = 0; i < SCRIPT_DIALECT_NAMES.length; ++i ) { 
 	        ProcessDialect dialect = ProcessDialectRegistry.getDialect(SCRIPT_DIALECT_NAMES[i]);
 
@@ -259,7 +255,8 @@ public class BPMN2DataServiceImpl implements DefinitionService, DeploymentEventL
 	    }
 	}
 
-	static void resetDialectExpressionBuilders() { 
+	@SuppressWarnings("rawtypes")
+    static void resetDialectExpressionBuilders() { 
 	    for( int i = 0; i < SCRIPT_DIALECT_NAMES.length; ++i ) { 
 	        ProcessDialect dialect = ProcessDialectRegistry.getDialect(SCRIPT_DIALECT_NAMES[i]);
 
@@ -510,4 +507,20 @@ public class BPMN2DataServiceImpl implements DefinitionService, DeploymentEventL
         
         return Collections.emptySet();
     }
+    
+    public Collection<ProcessDescRepoHelper> getProcessDefinitions(String deploymentId) {
+        
+
+        if (deploymentId != null && definitionCache.containsKey(deploymentId)) {
+
+            Map<String, ProcessDescRepoHelper> processes = definitionCache.get(deploymentId);
+            if (processes == null) {
+                throw new IllegalStateException("No processes available for given deployment id : " + deploymentId);
+            }
+            return processes.values();
+        }
+
+        return Collections.emptyList();
+    }
+    
 }

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/BPMN2DataServicesReferencesTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/BPMN2DataServicesReferencesTest.java
@@ -50,15 +50,12 @@ import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.kie.api.KieBase;
 import org.kie.api.KieServices;
 import org.kie.api.builder.ReleaseId;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.audit.AuditService;
 import org.kie.api.runtime.manager.audit.VariableInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
-import org.kie.api.runtime.process.WorkflowProcessInstance;
-import org.kie.api.runtime.rule.FactHandle;
 import org.kie.scanner.MavenRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -238,6 +235,12 @@ public class BPMN2DataServicesReferencesTest extends AbstractKieServicesBaseTest
         ProcessDefinition procDef = bpmn2Service.getProcessDefinition(deploymentId, processId);
         assertNotNull(procDef);
         
+        Collection<String> refProcesses = procDef.getReusableSubProcesses();
+        assertNotNull( "Null set of referenced processes", refProcesses );
+        assertFalse( "Empty set of referenced processes", refProcesses.isEmpty() );
+        assertEquals( "Number referenced processes", 1, refProcesses.size() );
+        assertEquals( "Imported class in processes", PROC_ID_ACTIVITY_CALLED, refProcesses.iterator().next() );
+        
         // run process (to verify that it works)
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "oldValue");
@@ -259,7 +262,7 @@ public class BPMN2DataServicesReferencesTest extends AbstractKieServicesBaseTest
         assertTrue( "Parent process did not call sub process", foundY);
        
         // check information about process 
-        Collection<String> refProcesses = bpmn2Service.getReusableSubProcesses(deploymentId, processId);
+        refProcesses = bpmn2Service.getReusableSubProcesses(deploymentId, processId);
         assertNotNull( "Null set of referenced processes", refProcesses );
         assertFalse( "Empty set of referenced processes", refProcesses.isEmpty() );
         assertEquals( "Number referenced processes", 1, refProcesses.size() );

--- a/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DefinitionService.java
+++ b/jbpm-services/jbpm-services-api/src/main/java/org/jbpm/services/api/DefinitionService.java
@@ -42,14 +42,14 @@ public interface DefinitionService {
 	 * @param deploymentId identifier of deployment this process belongs to, 
 	 * 			might be null if built definition does not need to be stored
 	 * @param bpmn2Content actual BPMN xml content as string to be parsed and processed
-	 * @param kieContainer the {@link KieContainer} instance that contains the deployment project: this should be used when 
+	 * @param classLoader the {@link KieContainer} instance that contains the deployment project: this should be used when 
 	 *          parsing the BPMN2 in case custom classes or other project resources (processes, rules) are referenced
 	 * @param cache indicates if the definition service should cache this <code>ProcessDefinition</code>
 	 * @return fully populated <code>ProcessDefinition</code>
 	 * @throws IllegalArgumentException in case build operation cannot be completed
 	 */
 	ProcessDefinition buildProcessDefinition(String deploymentId, String bpmn2Content,
-			KieContainer kieContainer, boolean cache) throws IllegalArgumentException;
+			ClassLoader classLoader, boolean cache) throws IllegalArgumentException;
 
 	/**
 	 * Returns previously built <code>ProcessDefinition</code>. 

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/main/java/org/jbpm/services/ejb/impl/DefinitionServiceEJBImpl.java
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/main/java/org/jbpm/services/ejb/impl/DefinitionServiceEJBImpl.java
@@ -29,7 +29,6 @@ import org.jbpm.services.api.DeploymentEventListener;
 import org.jbpm.services.api.model.ProcessDefinition;
 import org.jbpm.services.ejb.api.DefinitionServiceEJBLocal;
 import org.jbpm.services.ejb.api.DefinitionServiceEJBRemote;
-import org.kie.api.runtime.KieContainer;
 
 @Singleton
 @ConcurrencyManagement(ConcurrencyManagementType.CONTAINER)
@@ -38,8 +37,8 @@ public class DefinitionServiceEJBImpl extends BPMN2DataServiceImpl implements De
 
 	@Lock(LockType.WRITE)
 	@Override
-	public ProcessDefinition buildProcessDefinition(String deploymentId, String bpmn2Content, KieContainer kieContainer, boolean cache) throws IllegalArgumentException {
-		return super.buildProcessDefinition(deploymentId, bpmn2Content, kieContainer, cache);
+	public ProcessDefinition buildProcessDefinition(String deploymentId, String bpmn2Content, ClassLoader classLoader, boolean cache) throws IllegalArgumentException {
+		return super.buildProcessDefinition(deploymentId, bpmn2Content, classLoader, cache);
 	}
 	
 	@Lock(LockType.WRITE)


### PR DESCRIPTION
…d by name

Marco, here is an alternative way to look up reusable processes that are referenced by name to avoid using KieContainer in buildProcessDefinition method of the DefinitionService.

Just an idea to look at to see if we gain something with it