### PR TITLE
BPMSPL-111 - Add test coverage of task update events

### DIFF
--- a/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/test/TaskAuditBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/test/TaskAuditBaseTest.java
@@ -13,14 +13,11 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.jbpm.services.task.audit.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+package org.jbpm.services.task.audit.test;
 
 import java.util.HashMap;
 import java.util.List;
-
 import javax.inject.Inject;
 
 import org.jbpm.services.task.HumanTaskServicesBaseTest;
@@ -29,7 +26,6 @@ import org.jbpm.services.task.audit.commands.DeleteBAMTaskSummariesCommand;
 import org.jbpm.services.task.audit.commands.GetAuditEventsCommand;
 import org.jbpm.services.task.audit.commands.GetBAMTaskSummariesCommand;
 import org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl;
-import org.kie.internal.task.api.AuditTask;
 import org.jbpm.services.task.audit.service.TaskAuditService;
 import org.jbpm.services.task.utils.TaskFluent;
 import org.junit.Test;
@@ -37,62 +33,55 @@ import org.kie.api.task.model.Status;
 import org.kie.api.task.model.Task;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.query.QueryFilter;
+import org.kie.internal.task.api.AuditTask;
 import org.kie.internal.task.api.model.TaskEvent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
     @Inject
     protected TaskAuditService taskAuditService;
-    
+
     @Test
     public void testComplete() {
-      
         Task task = new TaskFluent().setName("This is my task name")
-                                    .addPotentialGroup("Knights Templer")
-                                    .setAdminUser("Administrator")
-                                    .getTask();
-       
-        
-        
+                .addPotentialGroup("Knights Templer")
+                .setAdminUser("Administrator")
+                .getTask();
+
         taskService.addTask(task, new HashMap<String, Object>());
         long taskId = task.getId();
-        
-         
+
         List<TaskSummary> allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
-        
-        
         assertEquals(1, allGroupAuditTasks.size());
-        
         assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Ready"));
 
-        taskService.claim(taskId, "Darth Vader");  
-        
+        taskService.claim(taskId, "Darth Vader");
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
-        
         assertEquals(0, allGroupAuditTasks.size());
-        
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("Darth Vader", null, null, null);
         assertEquals(1, allGroupAuditTasks.size());
         assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Reserved"));
-        
+
         taskService.release(taskId, "Darth Vader");
-        
-        allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy" , null, null, null);
-        
+
+        allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
         assertEquals(1, allGroupAuditTasks.size());
-        
         assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Ready"));
-        
-        taskService.claim(taskId, "Darth Vader");    
-        
+
+        taskService.claim(taskId, "Darth Vader");
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
         assertEquals(0, allGroupAuditTasks.size());
-        
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("Darth Vader", null, null, null);
         assertEquals(1, allGroupAuditTasks.size());
-        
         assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Reserved"));
-        
+
         // Go straight from Ready to Inprogress
         taskService.start(taskId, "Darth Vader");
 
@@ -107,178 +96,142 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
         assertEquals(Status.Completed, task2.getTaskData().getStatus());
         assertEquals("Darth Vader", task2.getTaskData().getActualOwner().getId());
 
-        List<TaskEvent> allTaskEvents = taskService.execute(new GetAuditEventsCommand(taskId, new QueryFilter(0,0)));
+        List<TaskEvent> allTaskEvents = taskService.execute(new GetAuditEventsCommand(taskId, new QueryFilter(0, 0)));
         assertEquals(6, allTaskEvents.size());
-     
-        // test DeleteAuditEventsCommand        
+
+        // test DeleteAuditEventsCommand
         int numFirstTaskEvents = allTaskEvents.size();
         task = new TaskFluent().setName("This is my task name 2")
-                                    .addPotentialGroup("Knights Templer")
-                                    .setAdminUser("Administrator")
-                                    .getTask();
+                .addPotentialGroup("Knights Templer")
+                .setAdminUser("Administrator")
+                .getTask();
         taskService.addTask(task, new HashMap<String, Object>());
         long secondTaskId = task.getId();
-        taskService.claim(secondTaskId, "Darth Vader");    
+        taskService.claim(secondTaskId, "Darth Vader");
         taskService.start(secondTaskId, "Darth Vader");
         taskService.complete(secondTaskId, "Darth Vader", null);
-       
+
         allTaskEvents = taskService.execute(new GetAuditEventsCommand());
         int numTaskEvents = allTaskEvents.size();
-        assertTrue("Expected more than " + numFirstTaskEvents + " events: "+ numTaskEvents, numTaskEvents > numFirstTaskEvents);
-        
+        assertTrue("Expected more than " + numFirstTaskEvents + " events: " + numTaskEvents,
+                numTaskEvents > numFirstTaskEvents);
+
         taskService.execute(new DeleteAuditEventsCommand(taskId));
         allTaskEvents = taskService.execute(new GetAuditEventsCommand());
         assertEquals(numTaskEvents - numFirstTaskEvents, allTaskEvents.size());
-        
+
         taskService.execute(new DeleteAuditEventsCommand());
         allTaskEvents = taskService.execute(new GetAuditEventsCommand());
         assertEquals(0, allTaskEvents.size());
-        
+
         // test get/delete BAM Task summaries commands
         List<BAMTaskSummaryImpl> bamTaskList = taskService.execute(new GetBAMTaskSummariesCommand());
-        assertEquals( "BAM Task Summary list size: ", 2, bamTaskList.size());
-        
+        assertEquals("BAM Task Summary list size: ", 2, bamTaskList.size());
+
         taskService.execute(new DeleteBAMTaskSummariesCommand(taskId));
         bamTaskList = taskService.execute(new GetBAMTaskSummariesCommand());
-        assertEquals( "BAM Task Summary list size after delete (task id: " + taskId + ") : ", 1, bamTaskList.size());
-        
+        assertEquals("BAM Task Summary list size after delete (task id: " + taskId + ") : ", 1, bamTaskList.size());
+
         bamTaskList = taskService.execute(new GetBAMTaskSummariesCommand(secondTaskId));
-        assertEquals( "BAM Task Summary list size after delete (task id: " + taskId + ") : ", 1, bamTaskList.size());
-        
+        assertEquals("BAM Task Summary list size after delete (task id: " + taskId + ") : ", 1, bamTaskList.size());
+
         taskService.execute(new DeleteBAMTaskSummariesCommand());
         bamTaskList = taskService.execute(new GetBAMTaskSummariesCommand());
-        assertEquals( "BAM Task Summary list size after delete (task id: " + taskId + ") : ", 0, bamTaskList.size());
-        
-        List<AuditTask> allHistoryAuditTasks = taskAuditService.getAllAuditTasks(new QueryFilter(0,0));
+        assertEquals("BAM Task Summary list size after delete (task id: " + taskId + ") : ", 0, bamTaskList.size());
+
+        List<AuditTask> allHistoryAuditTasks = taskAuditService.getAllAuditTasks(new QueryFilter(0, 0));
         assertEquals(2, allHistoryAuditTasks.size());
-        
     }
-    
+
     @Test
     public void testGroupTasks() {
-      
         Task task = new TaskFluent().setName("This is my task name")
-                                    .addPotentialUser("salaboy")
-                                    .addPotentialUser("krisv")
-                                    .addPotentialGroup("Knights Templer")
-                                    .setAdminUser("Administrator")
-                                    .getTask();
+                .addPotentialUser("salaboy")
+                .addPotentialUser("krisv")
+                .addPotentialGroup("Knights Templer")
+                .setAdminUser("Administrator")
+                .getTask();
         taskService.addTask(task, new HashMap<String, Object>());
-        long taskId = task.getId();
-        
-         
+
         List<TaskSummary> allGroupTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
-        
-        
         assertEquals(1, allGroupTasks.size());
-        
         assertTrue(allGroupTasks.get(0).getStatusId().equals("Ready"));
-        
-        List<AuditTask> allGroupAuditTasksByUser = taskAuditService.getAllGroupAuditTasksByUser("salaboy", new QueryFilter(0,0));
-        
+
+        List<AuditTask> allGroupAuditTasksByUser = taskAuditService.getAllGroupAuditTasksByUser("salaboy",
+                new QueryFilter(0, 0));
         assertEquals(1, allGroupAuditTasksByUser.size());
-        
         assertTrue(allGroupAuditTasksByUser.get(0).getStatus().equals("Ready"));
-        
     }
-    
+
     @Test
     public void testAdminTasks() {
-      
         Task task = new TaskFluent().setName("This is my task name")
-                                    .setAdminUser("salaboy")
-                                    .getTask();
-        
+                .setAdminUser("salaboy")
+                .getTask();
+
         taskService.addTask(task, new HashMap<String, Object>());
-        
-        
-         
+
         List<TaskSummary> allAdminTasks = taskService.getTasksAssignedAsBusinessAdministrator("salaboy", null);
-        
-        
         assertEquals(1, allAdminTasks.size());
-        
-        
-        
-        List<AuditTask> allAdminAuditTasksByUser = taskAuditService.getAllAdminAuditTasksByUser("salaboy", new QueryFilter(0,0));
-        
+
+        List<AuditTask> allAdminAuditTasksByUser = taskAuditService.getAllAdminAuditTasksByUser("salaboy",
+                new QueryFilter(0, 0));
         assertEquals(1, allAdminAuditTasksByUser.size());
-        
     }
-    
-    
+
+
     @Test
     public void testExitAfterClaim() {
         // One potential owner, should go straight to state Reserved
-        
-
         Task task = new TaskFluent().setName("This is my task name 2")
-                                    .addPotentialGroup("Knights Templer")
-                                    .setAdminUser("Administrator")
-                                    .getTask();
+                .addPotentialGroup("Knights Templer")
+                .setAdminUser("Administrator")
+                .getTask();
         taskService.addTask(task, new HashMap<String, Object>());
         long taskId = task.getId();
-        
-         
+
         List<TaskSummary> allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
-        
-        
-        
         assertEquals(1, allGroupAuditTasks.size());
         assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Ready"));
 
-        taskService.claim(taskId, "Darth Vader"); 
-        
+        taskService.claim(taskId, "Darth Vader");
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
         assertEquals(0, allGroupAuditTasks.size());
-        
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("Darth Vader", null, null, null);
         assertEquals(1, allGroupAuditTasks.size());
         assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Reserved"));
-        
-        taskService.exit(taskId, "Administrator");
-        
-        List<AuditTask> allHistoryAuditTasks = taskAuditService.getAllAuditTasks(new QueryFilter(0,0));
-        assertEquals(1, allHistoryAuditTasks.size());
-        
-        allGroupAuditTasks =taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
-        assertEquals(0, allGroupAuditTasks.size());
-        
-        
-        
-    }
-//    
-    @Test
-    public void testExitBeforeClaim() {
-       
 
-        Task task = new TaskFluent().setName("This is my task name 2")
-                                    .addPotentialGroup("Knights Templer")
-                                    .setAdminUser("Administrator")
-                                    .getTask();
-        taskService.addTask(task, new HashMap<String, Object>());
-        long taskId = task.getId();
-        
-         
-        List<TaskSummary> allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
-        
-        
-        assertEquals(1, allGroupAuditTasks.size());
-        assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Ready"));
-        
         taskService.exit(taskId, "Administrator");
-        
-        List<AuditTask> allHistoryAuditTasks = taskAuditService.getAllAuditTasks(new QueryFilter(0,0));
+
+        List<AuditTask> allHistoryAuditTasks = taskAuditService.getAllAuditTasks(new QueryFilter(0, 0));
         assertEquals(1, allHistoryAuditTasks.size());
-        
+
         allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
         assertEquals(0, allGroupAuditTasks.size());
-        
-        
-        
     }
-  
-    
 
-   
+    @Test
+    public void testExitBeforeClaim() {
+        Task task = new TaskFluent().setName("This is my task name 2")
+                .addPotentialGroup("Knights Templer")
+                .setAdminUser("Administrator")
+                .getTask();
+        taskService.addTask(task, new HashMap<String, Object>());
+        long taskId = task.getId();
+
+        List<TaskSummary> allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
+        assertEquals(1, allGroupAuditTasks.size());
+        assertTrue(allGroupAuditTasks.get(0).getStatusId().equals("Ready"));
+
+        taskService.exit(taskId, "Administrator");
+
+        List<AuditTask> allHistoryAuditTasks = taskAuditService.getAllAuditTasks(new QueryFilter(0, 0));
+        assertEquals(1, allHistoryAuditTasks.size());
+
+        allGroupAuditTasks = taskService.getTasksAssignedAsPotentialOwner("salaboy", null, null, null);
+        assertEquals(0, allGroupAuditTasks.size());
+    }
+
 }


### PR DESCRIPTION
I have written some tests for task update events. Some of them are marked as ignored since they fail and I am not sure about those use cases. I think that either it should not be allowed to pass null values or the behavior should be consistent so if you change some value to null this action will also be stored in task events. Now, the value is changed but there is no task event record for that.