### PR TITLE
Jbpm 4426

### DIFF
--- a/jbpm-test/src/test/java/org/jbpm/test/tasks/admin/AdminAPIsWithListenerTest.java
+++ b/jbpm-test/src/test/java/org/jbpm/test/tasks/admin/AdminAPIsWithListenerTest.java
@@ -21,7 +21,6 @@ import org.jbpm.test.JbpmJUnitBaseTestCase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
@@ -36,6 +35,7 @@ import org.kie.internal.event.KnowledgeRuntimeEventManager;
 import org.kie.internal.logger.KnowledgeRuntimeLoggerFactory;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.kie.internal.task.api.EventService;
+import org.kie.internal.task.api.InternalTaskService;
 import org.kie.internal.task.api.UserInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -329,14 +329,16 @@ public class AdminAPIsWithListenerTest extends JbpmJUnitBaseTestCase {
         em.close();
     }
 
-    @Ignore
     @Test
     public void automaticCleanUpForSubProcessWithPerProcessInstanceStrategy() throws Exception {
+        TaskCleanUpProcessEventListener taskCleanUpProcessEventListener = new TaskCleanUpProcessEventListener(null);
+
+        this.addProcessEventListener(taskCleanUpProcessEventListener);
 
         RuntimeManager manager = createRuntimeManager(Strategy.PROCESS_INSTANCE, "com.mycompany.sample", "subprocess-test/ht-main.bpmn", "subprocess-test/ht-sub.bpmn");
         RuntimeEngine runtime = getRuntimeEngine(ProcessInstanceIdContext.get());
+        taskCleanUpProcessEventListener.setTaskService((InternalTaskService) runtime.getTaskService());
         KieSession ksession = runtime.getKieSession();
-        ksession.addEventListener(new TaskCleanUpProcessEventListener(runtime.getTaskService()));
 
         // start a new process instance
         Map<String, Object> params = new HashMap<String, Object>();

--- a/jbpm-test/src/test/java/org/jbpm/test/tasks/admin/AdminAPIsWithListenerTest.java
+++ b/jbpm-test/src/test/java/org/jbpm/test/tasks/admin/AdminAPIsWithListenerTest.java
@@ -15,32 +15,17 @@
 
 package org.jbpm.test.tasks.admin;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.Persistence;
-
-import bitronix.tm.resource.jdbc.PoolingDataSource;
-import org.jbpm.runtime.manager.impl.RuntimeEnvironmentBuilder;
 import org.jbpm.services.task.admin.listener.TaskCleanUpProcessEventListener;
 import org.jbpm.services.task.identity.DefaultUserInfo;
-import org.jbpm.services.task.identity.JBossUserGroupCallbackImpl;
 import org.jbpm.test.JbpmJUnitBaseTestCase;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
-import org.kie.api.event.process.ProcessEventListener;
-import org.kie.api.io.ResourceType;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
-import org.kie.api.runtime.manager.RuntimeEnvironment;
 import org.kie.api.runtime.manager.RuntimeManager;
-import org.kie.api.runtime.manager.RuntimeManagerFactory;
 import org.kie.api.runtime.manager.audit.AuditService;
 import org.kie.api.runtime.manager.audit.ProcessInstanceLog;
 import org.kie.api.runtime.process.ProcessInstance;
@@ -48,14 +33,20 @@ import org.kie.api.task.TaskLifeCycleEventListener;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
 import org.kie.internal.event.KnowledgeRuntimeEventManager;
-import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.logger.KnowledgeRuntimeLoggerFactory;
 import org.kie.internal.runtime.manager.context.ProcessInstanceIdContext;
 import org.kie.internal.task.api.EventService;
-import org.kie.internal.task.api.UserGroupCallback;
 import org.kie.internal.task.api.UserInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 public class AdminAPIsWithListenerTest extends JbpmJUnitBaseTestCase {
 
@@ -338,6 +329,7 @@ public class AdminAPIsWithListenerTest extends JbpmJUnitBaseTestCase {
         em.close();
     }
 
+    @Ignore
     @Test
     public void automaticCleanUpForSubProcessWithPerProcessInstanceStrategy() throws Exception {
 

--- a/jbpm-test/src/test/java/org/jbpm/test/tasks/admin/AdminAPIsWithListenerTest.java
+++ b/jbpm-test/src/test/java/org/jbpm/test/tasks/admin/AdminAPIsWithListenerTest.java
@@ -270,11 +270,14 @@ public class AdminAPIsWithListenerTest extends JbpmJUnitBaseTestCase {
     @Test
     public void automaticCleanUpForSubProcessWithSingletonStrategy() throws Exception {
 
+        TaskCleanUpProcessEventListener taskCleanUpProcessEventListener = new TaskCleanUpProcessEventListener(null);
+        this.addProcessEventListener(taskCleanUpProcessEventListener);
+
         RuntimeManager manager = createRuntimeManager("subprocess-test/ht-main.bpmn", "subprocess-test/ht-sub.bpmn");
         RuntimeEngine runtime = getRuntimeEngine(ProcessInstanceIdContext.get());
+        taskCleanUpProcessEventListener.setTaskService((InternalTaskService) runtime.getTaskService());
         KieSession ksession = runtime.getKieSession();
-        ksession.addEventListener(new TaskCleanUpProcessEventListener(runtime.getTaskService()));
-        
+
         // start a new process instance
         Map<String, Object> params = new HashMap<String, Object>();
         ProcessInstance pi = ksession.startProcess("com.mycompany.sample", params);
@@ -331,8 +334,8 @@ public class AdminAPIsWithListenerTest extends JbpmJUnitBaseTestCase {
 
     @Test
     public void automaticCleanUpForSubProcessWithPerProcessInstanceStrategy() throws Exception {
-        TaskCleanUpProcessEventListener taskCleanUpProcessEventListener = new TaskCleanUpProcessEventListener(null);
 
+        TaskCleanUpProcessEventListener taskCleanUpProcessEventListener = new TaskCleanUpProcessEventListener(null);
         this.addProcessEventListener(taskCleanUpProcessEventListener);
 
         RuntimeManager manager = createRuntimeManager(Strategy.PROCESS_INSTANCE, "com.mycompany.sample", "subprocess-test/ht-main.bpmn", "subprocess-test/ht-sub.bpmn");


### PR DESCRIPTION
The test which was added for JBPM-4426 to ensure that `TaskCleanUpProcessEventListener` works fine uses `SINGLETON` strategy.

This pull request contains a unit test which uses `PROCESS_INSTANCE` strategy and breaks JBPM-4426. I wasn't able to detect what causes the problem so I ignored the test for now.

All I was able to figure out is that `WorkflowProcessInstanceImpl.setState` fires `fireAfterProcessCompleted` for both processes. 

The problem is that in `ProcessEventSupport.fireAfterProcessCompleted(ProcessInstance instance, KnowledgeRuntime kruntime)` the iterator `Iterator iter = this.getEventListenersIterator();` doesn't contain the `TaskCleanUpProcessEventListener`.