### PR TITLE
JBPM-4691 name() for fluent API CompositeNode is missing

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/CompositeNodeFactory.java
+++ b/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/factory/CompositeNodeFactory.java
@@ -51,6 +51,11 @@ public class CompositeNodeFactory extends RuleFlowNodeContainerFactory {
     	return (CompositeContextNode) getNodeContainer();
     }
 
+    public CompositeNodeFactory name(String name) {
+        getCompositeNode().setName(name);
+        return this;
+    }
+
     public CompositeNodeFactory variable(String name, DataType type) {
     	return variable(name, type, null);
     }


### PR DESCRIPTION
Added name() method to CompositeNodeFactory.