### PR TITLE
BPMSPL-128 - Add test-coverage for JavaScript support

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -233,11 +233,14 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("name", "krisv");
+
         WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.startProcess("ScriptTask", params);
         assertEquals("Entry", processInstance.getVariable("x"));
         assertNull(processInstance.getVariable("y"));
+
         ksession.getWorkItemManager().completeWorkItem(handler.getWorkItem().getId(), null);
         assertEquals("Exit", getProcessVarValue(processInstance, "y"));
+        assertEquals("tester", processInstance.getVariable("surname"));
     }
 
     @Test
@@ -517,28 +520,28 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         
         ksession.execute(new GenericCommand<Void>() {
 
-			@Override
-			public Void execute(Context context) {
-				
-				KieSession ksession = ((KnowledgeCommandContext) context).getKieSession();
-		        ProcessInstance processInstance = ksession.getProcessInstance(pId);
-		        assertNotNull(processInstance);
-		        NodeInstance nodeInstance = ((WorkflowProcessInstance) processInstance)
-		        		.getNodeInstance(((org.drools.core.process.instance.WorkItem)workItem).getNodeInstanceId());
-		        
-		        assertNotNull(nodeInstance);
-		        assertTrue(nodeInstance instanceof WorkItemNodeInstance);
-		        String deploymentId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getDeploymentId();
-		        long nodeInstanceId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeInstanceId();
-		        long nodeId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeId();
-		        
-		        assertEquals(((org.drools.core.process.instance.WorkItem)workItem).getDeploymentId(), deploymentId);
-		        assertEquals(((org.drools.core.process.instance.WorkItem)workItem).getNodeId(), nodeId);
-		        assertEquals(((org.drools.core.process.instance.WorkItem)workItem).getNodeInstanceId(), nodeInstanceId);
-		        
-		        return null;
-			}
-		});
+            @Override
+            public Void execute(Context context) {
+
+                KieSession ksession = ((KnowledgeCommandContext) context).getKieSession();
+                ProcessInstance processInstance = ksession.getProcessInstance(pId);
+                assertNotNull(processInstance);
+                NodeInstance nodeInstance = ((WorkflowProcessInstance) processInstance)
+                        .getNodeInstance(((org.drools.core.process.instance.WorkItem) workItem).getNodeInstanceId());
+
+                assertNotNull(nodeInstance);
+                assertTrue(nodeInstance instanceof WorkItemNodeInstance);
+                String deploymentId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getDeploymentId();
+                long nodeInstanceId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeInstanceId();
+                long nodeId = ((WorkItemNodeInstance) nodeInstance).getWorkItem().getNodeId();
+
+                assertEquals(((org.drools.core.process.instance.WorkItem) workItem).getDeploymentId(), deploymentId);
+                assertEquals(((org.drools.core.process.instance.WorkItem) workItem).getNodeId(), nodeId);
+                assertEquals(((org.drools.core.process.instance.WorkItem) workItem).getNodeInstanceId(), nodeInstanceId);
+
+                return null;
+            }
+        });
         
 
         
@@ -700,7 +703,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
 		ksession = createKnowledgeSession(kbase);
 		TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
 		ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
-				workItemHandler);
+                workItemHandler);
 		Map<String, Object> params = new HashMap<String, Object>();
 		params.put("x", "oldValue");
 		ProcessInstance processInstance = ksession.startProcess(
@@ -1229,8 +1232,8 @@ public class ActivityTest extends JbpmBpmn2TestCase {
                         assertEquals("SimpleService", workItem.getParameter("interfaceImplementationRef"));
                         super.executeWorkItem(workItem, manager);
                     }
-            
-        });
+
+                });
         Map<String, Object> params = new HashMap<String, Object>();
         WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession
                 .startProcess("org.jboss.qa.jbpm.CallWS", params);
@@ -1583,13 +1586,13 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-CallActivityWithTransformation.bpmn2", "BPMN2-CallActivitySubProcess.bpmn2");
         ksession = createKnowledgeSession(kbase);
         final List<ProcessInstance> instances = new ArrayList<ProcessInstance>();
-        ksession.addEventListener(new DefaultProcessEventListener(){
+        ksession.addEventListener(new DefaultProcessEventListener() {
 
-			@Override
-			public void beforeProcessStarted(ProcessStartedEvent event) {
-				instances.add(event.getProcessInstance());
-			}
-        	
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                instances.add(event.getProcessInstance());
+            }
+
         });
         
         
@@ -1603,7 +1606,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertEquals("oldValue",((WorkflowProcessInstance) instances.get(0)).getVariable("x"));
         assertEquals("NEW VALUE",((WorkflowProcessInstance) instances.get(0)).getVariable("y"));
         // assert variables of subprocess, first in start (input transformation, then on end output transformation)
-        assertEquals("OLDVALUE",((WorkflowProcessInstance) instances.get(1)).getVariable("subX"));
+        assertEquals("OLDVALUE", ((WorkflowProcessInstance) instances.get(1)).getVariable("subX"));
         assertEquals("new value",((WorkflowProcessInstance) instances.get(1)).getVariable("subY"));
     }
     

--- a/jbpm-bpmn2/src/test/resources/BPMN2-ScriptTaskJS.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-ScriptTaskJS.bpmn2
@@ -25,13 +25,18 @@
     <!-- nodes -->
     <startEvent id="_1" name="StartProcess" />
     <scriptTask id="_2" name="Hello" scriptFormat="http://www.javascript.com/javascript" >
-      <script>var text = 'Hello ';
-print(text + kcontext.getVariable('name') + '\n');
-try {
-   somethingInvalid;
-} catch(err) {
-    print(err + '\n');
-}</script>
+      <script>
+        // this is comment
+
+        kcontext.setVariable('surname', "tester");
+        var text = 'Hello ';
+        print(text + kcontext.getVariable('name') + '\n');
+        try {
+            somethingInvalid;
+        } catch(err) {
+            print(err + '\n');
+        }
+      </script>
     </scriptTask>
     <userTask id="_3" name="Hello" >
       <extensionElements>

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptActionBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptActionBuilderTest.java
@@ -9,18 +9,16 @@ import org.drools.core.common.InternalWorkingMemory;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.impl.KnowledgePackageImpl;
 import org.drools.core.spi.ProcessContext;
-import org.jbpm.marshalling.impl.JBPMMessages;
 import org.jbpm.process.builder.dialect.ProcessDialect;
 import org.jbpm.process.builder.dialect.ProcessDialectRegistry;
 import org.jbpm.process.builder.dialect.javascript.JavaScriptActionBuilder;
-import org.jbpm.process.instance.impl.JavaScriptAction;
+import org.jbpm.process.instance.impl.Action;
 import org.jbpm.test.util.AbstractBaseTest;
 import org.jbpm.workflow.core.DroolsAction;
 import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
 import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
 import org.jbpm.workflow.core.node.ActionNode;
 import org.junit.Test;
-import org.kie.api.runtime.process.NodeInstance;
 import org.kie.internal.KnowledgeBase;
 import org.kie.internal.KnowledgeBaseFactory;
 import org.kie.internal.runtime.StatefulKnowledgeSession;
@@ -38,7 +36,7 @@ public class JavaScriptActionBuilderTest extends AbstractBaseTest {
         final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
 
         ActionDescr actionDescr = new ActionDescr();
-        actionDescr.setText( "var testString; testString = \"mega-vagon\";" );
+        actionDescr.setText( "var testString; print('Hello')" );
 
         KnowledgeBuilderImpl pkgBuilder = new KnowledgeBuilderImpl( pkg );
         DialectCompiletimeRegistry dialectRegistry = pkgBuilder.getPackageRegistry( pkg.getName() ).getDialectCompiletimeRegistry();
@@ -78,7 +76,7 @@ public class JavaScriptActionBuilderTest extends AbstractBaseTest {
         wm.setGlobal("testField", "vagon");
 
         ProcessContext processContext = new ProcessContext( ((InternalWorkingMemory) wm).getKnowledgeRuntime() );
-        ((JavaScriptAction) actionNode.getAction().getMetaData("Action")).execute(processContext);
+        ((Action) actionNode.getAction().getMetaData("Action")).execute(processContext);
 
         assertEquals("vagon", wm.getGlobal("testField").toString());
     }

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptActionBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptActionBuilderTest.java
@@ -1,0 +1,7 @@
+package org.jbpm.process.builder;
+
+/**
+ * Created by dhanak on 6/30/15.
+ */
+public class JavaScriptActionBuilderTest {
+}

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptActionBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptActionBuilderTest.java
@@ -1,7 +1,85 @@
 package org.jbpm.process.builder;
 
-/**
- * Created by dhanak on 6/30/15.
- */
-public class JavaScriptActionBuilderTest {
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.compiler.DialectCompiletimeRegistry;
+import org.drools.compiler.lang.descr.ActionDescr;
+import org.drools.compiler.lang.descr.ProcessDescr;
+import org.drools.core.common.InternalWorkingMemory;
+import org.drools.core.definitions.InternalKnowledgePackage;
+import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.drools.core.spi.ProcessContext;
+import org.jbpm.marshalling.impl.JBPMMessages;
+import org.jbpm.process.builder.dialect.ProcessDialect;
+import org.jbpm.process.builder.dialect.ProcessDialectRegistry;
+import org.jbpm.process.builder.dialect.javascript.JavaScriptActionBuilder;
+import org.jbpm.process.instance.impl.JavaScriptAction;
+import org.jbpm.test.util.AbstractBaseTest;
+import org.jbpm.workflow.core.DroolsAction;
+import org.jbpm.workflow.core.impl.DroolsConsequenceAction;
+import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
+import org.jbpm.workflow.core.node.ActionNode;
+import org.junit.Test;
+import org.kie.api.runtime.process.NodeInstance;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+public class JavaScriptActionBuilderTest extends AbstractBaseTest {
+
+    @Test
+    public void testSimpleAction() throws Exception {
+        final InternalKnowledgePackage pkg = new KnowledgePackageImpl("pkg1");
+
+        ActionDescr actionDescr = new ActionDescr();
+        actionDescr.setText( "var testString; testString = \"mega-vagon\";" );
+
+        KnowledgeBuilderImpl pkgBuilder = new KnowledgeBuilderImpl( pkg );
+        DialectCompiletimeRegistry dialectRegistry = pkgBuilder.getPackageRegistry( pkg.getName() ).getDialectCompiletimeRegistry();
+
+        ProcessDescr processDescr = new ProcessDescr();
+        processDescr.setClassName("Process1");
+        processDescr.setName("Process1");
+
+        WorkflowProcessImpl process = new WorkflowProcessImpl();
+        process.setName("Process1");
+        process.setPackageName("pkg1");
+
+        ProcessBuildContext context = new ProcessBuildContext(pkgBuilder, pkgBuilder.getPackage(), null, processDescr, dialectRegistry, null);
+        context.init( pkgBuilder, pkg, null, dialectRegistry, null, null);
+
+        pkgBuilder.addPackageFromDrl(new StringReader("package pkg1;\nglobal String testField;\n"));
+
+        ActionNode actionNode = new ActionNode();
+        DroolsAction action = new DroolsConsequenceAction("JavaScript", null);
+        actionNode.setAction(action);
+
+        ProcessDialect dialect = ProcessDialectRegistry.getDialect("JavaScript");
+        dialect.getActionBuilder().build( context, action, actionDescr, actionNode );
+        dialect.addProcess(context);
+
+        final JavaScriptActionBuilder builder = new JavaScriptActionBuilder();
+        builder.build(context,
+                action,
+                actionDescr,
+                actionNode);
+
+
+        final KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        kbase.addKnowledgePackages((Collection) Arrays.asList(pkgBuilder.getPackage()));
+        final StatefulKnowledgeSession wm = kbase.newStatefulKnowledgeSession();
+
+        wm.setGlobal("testField", "vagon");
+
+        ProcessContext processContext = new ProcessContext( ((InternalWorkingMemory) wm).getKnowledgeRuntime() );
+        ((JavaScriptAction) actionNode.getAction().getMetaData("Action")).execute(processContext);
+
+        assertEquals("vagon", wm.getGlobal("testField").toString());
+    }
 }

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
@@ -1,0 +1,7 @@
+package org.jbpm.process.builder;
+
+/**
+ * Created by dhanak on 7/1/15.
+ */
+public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
+}

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
@@ -55,7 +55,7 @@ public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
                 dialectRegistry,
                 null );
 
-        pkgBuilder.addPackageFromDrl(new StringReader("package pkg1;\n global Boolean value;\n global Integer count;"));
+        pkgBuilder.addPackageFromDrl(new StringReader("package pkg1;\n global Boolean value;\n"));
 
         ReturnValueConstraintEvaluator node = new ReturnValueConstraintEvaluator();
 
@@ -79,7 +79,6 @@ public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
         splitInstance.setProcessInstance(processInstance);
 
         ksession.setGlobal("value", false);
-        ksession.setGlobal("count", 101);
 
         assertTrue(node.evaluate(splitInstance,
                         null,

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
@@ -8,12 +8,9 @@ import org.drools.compiler.lang.descr.ProcessDescr;
 import org.drools.core.common.InternalKnowledgeRuntime;
 import org.drools.core.definitions.InternalKnowledgePackage;
 import org.drools.core.definitions.impl.KnowledgePackageImpl;
-import org.jbpm.process.builder.dialect.javascript.JavaScriptProcessDialect;
 import org.jbpm.process.builder.dialect.javascript.JavaScriptReturnValueEvaluatorBuilder;
 import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
 import org.jbpm.ruleflow.instance.RuleFlowProcessInstance;
-import org.jbpm.workflow.core.Constraint;
-import org.jbpm.workflow.core.impl.ConstraintImpl;
 import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
 import org.jbpm.workflow.instance.node.SplitInstance;
 import org.junit.Test;
@@ -43,7 +40,7 @@ public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
         process.setPackageName("pkg1");
 
         ReturnValueDescr descr = new ReturnValueDescr();
-        descr.setText("function validate() {return true;} validate();");
+        descr.setText("function validate() {return value;} validate();");
 
         KnowledgeBuilderImpl pkgBuilder = new KnowledgeBuilderImpl( pkg );
         DialectCompiletimeRegistry dialectRegistry = pkgBuilder.getPackageRegistry( pkg.getName() ).getDialectCompiletimeRegistry();

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
@@ -26,6 +26,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
@@ -80,25 +81,24 @@ public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
         ksession.setGlobal("value", false);
         ksession.setGlobal("count", 101);
 
-
-        Constraint constraint = new ConstraintImpl();
-        constraint.setDialect("JavaScript");
-        constraint.setConstraint("value === false && count > 100");
-        node.setConstraint(constraint.getConstraint());
-
         assertTrue(node.evaluate(splitInstance,
                         null,
-                        constraint)
+                        null)
         );
 
-        // Set global values to break constraints
-        ksession.setGlobal("value", true);
-        ksession.setGlobal("count", 99);
+        // Build second time with reutrn value evaulator returning false
+        ReturnValueDescr descr2 = new ReturnValueDescr();
+        descr.setText("function invalidate() {return false;} invalidate();");
 
-        // Returns true because constraint argument is ignored -> intended?
-        assertTrue(node.evaluate(splitInstance,
+        final JavaScriptReturnValueEvaluatorBuilder builder2 = new JavaScriptReturnValueEvaluatorBuilder();
+        builder2.build(context,
+                node,
+                descr,
+                null);
+
+        assertFalse(node.evaluate(splitInstance,
                         null,
-                        constraint)
+                        null)
         );
     }
 

--- a/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
+++ b/jbpm-flow-builder/src/test/java/org/jbpm/process/builder/JavaScriptReturnValueConstraintEvaluatorBuilderTest.java
@@ -1,7 +1,105 @@
 package org.jbpm.process.builder;
 
-/**
- * Created by dhanak on 7/1/15.
- */
+
+import org.drools.compiler.builder.impl.KnowledgeBuilderImpl;
+import org.drools.compiler.compiler.DialectCompiletimeRegistry;
+import org.drools.compiler.compiler.ReturnValueDescr;
+import org.drools.compiler.lang.descr.ProcessDescr;
+import org.drools.core.common.InternalKnowledgeRuntime;
+import org.drools.core.definitions.InternalKnowledgePackage;
+import org.drools.core.definitions.impl.KnowledgePackageImpl;
+import org.jbpm.process.builder.dialect.javascript.JavaScriptProcessDialect;
+import org.jbpm.process.builder.dialect.javascript.JavaScriptReturnValueEvaluatorBuilder;
+import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
+import org.jbpm.ruleflow.instance.RuleFlowProcessInstance;
+import org.jbpm.workflow.core.Constraint;
+import org.jbpm.workflow.core.impl.ConstraintImpl;
+import org.jbpm.workflow.core.impl.WorkflowProcessImpl;
+import org.jbpm.workflow.instance.node.SplitInstance;
+import org.junit.Test;
+import org.kie.internal.KnowledgeBase;
+import org.kie.internal.KnowledgeBaseFactory;
+import org.kie.internal.definition.KnowledgePackage;
+import org.kie.internal.runtime.StatefulKnowledgeSession;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
 public class JavaScriptReturnValueConstraintEvaluatorBuilderTest {
+    @Test
+    public void testSimpleReturnValueConstraintEvaluator() throws Exception {
+        final InternalKnowledgePackage pkg = new KnowledgePackageImpl( "pkg1" );
+
+        ProcessDescr processDescr = new ProcessDescr();
+        processDescr.setClassName( "Process1" );
+        processDescr.setName( "Process1" );
+
+        WorkflowProcessImpl process = new WorkflowProcessImpl();
+        process.setName( "Process1" );
+        process.setPackageName("pkg1");
+
+        ReturnValueDescr descr = new ReturnValueDescr();
+        descr.setText("function validate() {return true;} validate();");
+
+        KnowledgeBuilderImpl pkgBuilder = new KnowledgeBuilderImpl( pkg );
+        DialectCompiletimeRegistry dialectRegistry = pkgBuilder.getPackageRegistry( pkg.getName() ).getDialectCompiletimeRegistry();
+
+        ProcessBuildContext context = new ProcessBuildContext( pkgBuilder,
+                pkg,
+                process,
+                processDescr,
+                dialectRegistry,
+                null );
+
+        pkgBuilder.addPackageFromDrl(new StringReader("package pkg1;\n global Boolean value;\n global Integer count;"));
+
+        ReturnValueConstraintEvaluator node = new ReturnValueConstraintEvaluator();
+
+        final JavaScriptReturnValueEvaluatorBuilder builder = new JavaScriptReturnValueEvaluatorBuilder();
+        builder.build(context,
+                node,
+                descr,
+                null);
+
+        final KnowledgeBase kbase = KnowledgeBaseFactory.newKnowledgeBase();
+        List<KnowledgePackage> packages = new ArrayList<KnowledgePackage>();
+        packages.add( pkgBuilder.getPackage() );
+        kbase.addKnowledgePackages(packages);
+        final StatefulKnowledgeSession ksession = kbase.newStatefulKnowledgeSession();
+
+
+        RuleFlowProcessInstance processInstance = new RuleFlowProcessInstance();
+        processInstance.setKnowledgeRuntime((InternalKnowledgeRuntime) ksession);
+
+        SplitInstance splitInstance = new SplitInstance();
+        splitInstance.setProcessInstance(processInstance);
+
+        ksession.setGlobal("value", false);
+        ksession.setGlobal("count", 101);
+
+
+        Constraint constraint = new ConstraintImpl();
+        constraint.setDialect("JavaScript");
+        constraint.setConstraint("value === false && count > 100");
+        node.setConstraint(constraint.getConstraint());
+
+        assertTrue(node.evaluate(splitInstance,
+                        null,
+                        constraint)
+        );
+
+        // Set global values to break constraints
+        ksession.setGlobal("value", true);
+        ksession.setGlobal("count", 99);
+
+        // Returns true because constraint argument is ignored -> intended?
+        assertTrue(node.evaluate(splitInstance,
+                        null,
+                        constraint)
+        );
+    }
+
 }


### PR DESCRIPTION
I have written tests for JavaScript support in core engine, however I can't compile JavaScript expressions as it is done in Java and MVEL tests as drools does not provide JavaScriptDialect that can compile expression. Thanks to that I can't correctly test  globals  with JavaScript.


 