### PR TITLE
BPMSPL-128 - Modify ScriptTaskTest to test JavaScript usage

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskTest.java
@@ -75,7 +75,7 @@ public class ScriptTaskTest extends JbpmTestCase {
         assertChangedVariable(ipel, "output", "BirskyKorcaskoVandrovec", "VandrovecBirskyKorcasko");
         assertLeft(ipel, "scriptMvel");
         assertTriggered(ipel, "scriptJavaScript");
-        assertChangedVariable(ipel, "output", "VandrovecBirskyKorcasko", "JavaScript Node");
+        assertChangedVariable(ipel, "output", "VandrovecBirskyKorcasko", "JavaScript Node: Vandrovec");
         assertLeft(ipel, "scriptJavaScript");
         assertNextNode(ipel, "end");
         assertProcessCompleted(ipel, SCRIPT_TASK_ID);

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/task/ScriptTaskTest.java
@@ -74,6 +74,9 @@ public class ScriptTaskTest extends JbpmTestCase {
         assertTriggered(ipel, "scriptMvel");
         assertChangedVariable(ipel, "output", "BirskyKorcaskoVandrovec", "VandrovecBirskyKorcasko");
         assertLeft(ipel, "scriptMvel");
+        assertTriggered(ipel, "scriptJavaScript");
+        assertChangedVariable(ipel, "output", "VandrovecBirskyKorcasko", "JavaScript Node");
+        assertLeft(ipel, "scriptJavaScript");
         assertNextNode(ipel, "end");
         assertProcessCompleted(ipel, SCRIPT_TASK_ID);
     }

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/ScriptTask.bpmn
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/ScriptTask.bpmn
@@ -34,7 +34,13 @@
         </scriptTask>
         <scriptTask id="scriptJavaScript" name="scriptJavaScript" scriptFormat="http://www.javascript.com/javascript">
             <script>
-                temp = "JavaScript Node"
+                temp = "JavaScript Node: " + kcontext.getVariable("person").name;
+                try {
+                    print(person.name);
+                } catch (err) {
+                    print(err);
+                    temp = err;
+                }
 
                 kcontext.setVariable("output", temp);
             </script>

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/ScriptTask.bpmn
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/task/ScriptTask.bpmn
@@ -32,9 +32,17 @@
                 kcontext.setVariable("output", temp);
             </script>
         </scriptTask>
+        <scriptTask id="scriptJavaScript" name="scriptJavaScript" scriptFormat="http://www.javascript.com/javascript">
+            <script>
+                temp = "JavaScript Node"
+
+                kcontext.setVariable("output", temp);
+            </script>
+        </scriptTask>
         <endEvent id="end" name="end"/>
         <sequenceFlow id="sf1" sourceRef="start" targetRef="scriptJava"/>
         <sequenceFlow id="sf2" sourceRef="scriptJava" targetRef="scriptMvel"/>
-        <sequenceFlow id="sf3" sourceRef="scriptMvel" targetRef="end"/>
+        <sequenceFlow id="sf3" sourceRef="scriptMvel" targetRef="scriptJavaScript"/>
+        <sequenceFlow id="sf4" sourceRef="scriptJavaScript" targetRef="end"/>
     </process>
 </definitions>


### PR DESCRIPTION
Test currently fails on line 78: Where actual result of tested variable does not match the expected result.
org.junit.ComparisonFailure: 
Expected :"JavaScript Node: Vandrovec"
Actual : {}

This happens because process variables aren't accessible from JavaScript code inside ScriptTask. For example person. They can be accessed using kcontext.getVariable() but it is not possible to directly access them, like  it is done  in MVEL or Java scripts.
Accessing them throws  ReferenceError. 

Test should run correctly once process variables are accessible from JavaScript.
