### PR TITLE
JBPM-4749 Persistence tests don't support Postgres Plus

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserGroupCallbackImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserGroupCallbackImplTest.java
@@ -248,7 +248,8 @@ public class DBUserGroupCallbackImplTest {
                 }
                 pds.getDriverProperties().put("REQUEST_HA_SESSION", "false");
                 pds.getDriverProperties().put("networkProtocol", "Tds");
-            } else if (driverClass.startsWith("org.postgresql")) {
+            // com.edb is Postgres Plus.
+            } else if (driverClass.startsWith("org.postgresql") || driverClass.startsWith("com.edb")) {
                 for (String propertyName : new String[]{"databaseName", "portNumber", "serverName"}) {
                     pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));
                 }

--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
@@ -229,7 +229,8 @@ public class PersistenceUtil {
                 }
                 pds.getDriverProperties().put("REQUEST_HA_SESSION", "false");
                 pds.getDriverProperties().put("networkProtocol", "Tds");
-            } else if (driverClass.startsWith("org.postgresql")) {
+            // com.edb is Postgres Plus.
+            } else if (driverClass.startsWith("org.postgresql") || driverClass.startsWith("com.edb")) {
                 for (String propertyName : new String[] { "databaseName", "portNumber", "serverName" }) {
                     pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));
                 }


### PR DESCRIPTION
Added support for com.edb.Driver class to data source properties handling.

Please if it's possible, merge it also to 6.3.x and 6.2.x branch. Without this we cannot execute community tests on Postgres Plus. 