### PR TITLE
JBPM-4750 Missing hibernate.default_schema property in test persistence.xml files

### DIFF
--- a/jbpm-audit/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-audit/src/test/filtered-resources/META-INF/persistence.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.0" 
-             xmlns="http://java.sun.com/xml/ns/persistence" 
-             xmlns:orm="http://java.sun.com/xml/ns/persistence/orm" 
+<persistence version="2.0"
+             xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd 
                                  http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
@@ -32,6 +32,7 @@
       <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
       <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
       <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
       <property name="hibernate.id.new_generator_mappings" value="false" />
@@ -41,7 +42,7 @@
 
   <persistence-unit name="org.jbpm.logging.jta" transaction-type="JTA">
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
-    
+
     <class>org.jbpm.process.audit.ProcessInstanceLog</class>
     <class>org.jbpm.process.audit.NodeInstanceLog</class>
     <class>org.jbpm.process.audit.VariableInstanceLog</class>
@@ -56,16 +57,17 @@
       <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
       <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
       <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
       <property name="hibernate.id.new_generator_mappings" value="false" />
       <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform" />
     </properties>
   </persistence-unit>
-  
+
   <persistence-unit name="org.jbpm.logging.local" transaction-type="RESOURCE_LOCAL">
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
-    
+
     <class>org.jbpm.process.audit.ProcessInstanceLog</class>
     <class>org.jbpm.process.audit.NodeInstanceLog</class>
     <class>org.jbpm.process.audit.VariableInstanceLog</class>
@@ -80,6 +82,7 @@
       <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
       <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
       <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
       <property name="hibernate.id.new_generator_mappings" value="false" />

--- a/jbpm-audit/src/test/filtered-resources/datasource.properties
+++ b/jbpm-audit/src/test/filtered-resources/datasource.properties
@@ -16,5 +16,6 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 makeBaseDb=false
 testMarshalling=false

--- a/jbpm-bpmn2/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-bpmn2/src/test/filtered-resources/META-INF/persistence.xml
@@ -1,41 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<persistence version="2.0" 
-             xmlns="http://java.sun.com/xml/ns/persistence" 
-             xmlns:orm="http://java.sun.com/xml/ns/persistence/orm" 
-             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<persistence version="2.0"
+             xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:orm="http://java.sun.com/xml/ns/persistence/orm"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
              xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd 
                                  http://java.sun.com/xml/ns/persistence/orm http://java.sun.com/xml/ns/persistence/orm_2_0.xsd">
 
-    <persistence-unit name="org.jbpm.persistence.jpa" transaction-type="JTA">
-        <provider>org.hibernate.ejb.HibernatePersistence</provider>
-        <jta-data-source>jdbc/testDS1</jta-data-source>        
-        <mapping-file>META-INF/JBPMorm.xml</mapping-file> 
-        
-        <class>org.drools.persistence.info.SessionInfo</class>
-        <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
-        <class>org.drools.persistence.info.WorkItemInfo</class>
-        
-        <class>org.jbpm.process.audit.ProcessInstanceLog</class>
-        <class>org.jbpm.process.audit.NodeInstanceLog</class>
-        <class>org.jbpm.process.audit.VariableInstanceLog</class>
-        
-        <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
-        <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>        
-        
-	    <properties>
-	        <property name="hibernate.max_fetch_depth" value="3"/>
-		    <property name="hibernate.hbm2ddl.auto" value="create" />
-            <property name="hibernate.show_sql" value="false" />	
-	        <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
-         
-            <property name="hibernate.connection.driver_class" value="${maven.jdbc.driver.class}" />
-            <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
-            <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
-            <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
+  <persistence-unit name="org.jbpm.persistence.jpa" transaction-type="JTA">
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <jta-data-source>jdbc/testDS1</jta-data-source>
+    <mapping-file>META-INF/JBPMorm.xml</mapping-file>
 
-            <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
-            <property name="hibernate.id.new_generator_mappings" value="false" />            
-            <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform" />
-	    </properties>        
-    </persistence-unit>
+    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <class>org.drools.persistence.info.WorkItemInfo</class>
+
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    <class>org.jbpm.process.audit.NodeInstanceLog</class>
+    <class>org.jbpm.process.audit.VariableInstanceLog</class>
+
+    <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+
+    <properties>
+      <property name="hibernate.max_fetch_depth" value="3"/>
+      <property name="hibernate.hbm2ddl.auto" value="create"/>
+      <property name="hibernate.show_sql" value="false"/>
+      <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+
+      <property name="hibernate.connection.driver_class" value="${maven.jdbc.driver.class}"/>
+      <property name="hibernate.connection.url" value="${maven.jdbc.url}"/>
+      <property name="hibernate.connection.username" value="${maven.jdbc.username}"/>
+      <property name="hibernate.connection.password" value="${maven.jdbc.password}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
+
+      <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
+      <property name="hibernate.id.new_generator_mappings" value="false"/>
+      <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform"/>
+    </properties>
+  </persistence-unit>
 </persistence>

--- a/jbpm-bpmn2/src/test/filtered-resources/datasource.properties
+++ b/jbpm-bpmn2/src/test/filtered-resources/datasource.properties
@@ -16,6 +16,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 dbBaseDir=${basedir}
 makeBaseDb=false
 testMarshalling=false

--- a/jbpm-human-task/jbpm-human-task-core/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/filtered-resources/META-INF/persistence.xml
@@ -36,6 +36,7 @@
    
     <properties>
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <property name="hibernate.max_fetch_depth" value="3" />
       <property name="hibernate.hbm2ddl.auto" value="create-drop" />

--- a/jbpm-human-task/jbpm-human-task-core/src/test/filtered-resources/datasource.properties
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/filtered-resources/datasource.properties
@@ -15,6 +15,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 makeBaseDb=false
 testMarshalling=false
 txType=${maven.tx.type}

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserGroupCallbackImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/DBUserGroupCallbackImplTest.java
@@ -231,6 +231,7 @@ public class DBUserGroupCallbackImplTest {
                     pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));
                 }
                 pds.getDriverProperties().put("driverType", "4");
+                pds.getDriverProperties().put("currentSchema", dsProps.getProperty("defaultSchema"));
             } else if (driverClass.startsWith("com.microsoft")) {
                 for (String propertyName : new String[]{"serverName", "portNumber", "databaseName"}) {
                     pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));

--- a/jbpm-human-task/jbpm-human-task-jpa/src/test/resources/META-INF/persistence.xml
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/test/resources/META-INF/persistence.xml
@@ -36,6 +36,7 @@
    
     <properties>
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <property name="hibernate.max_fetch_depth" value="3" />
       <property name="hibernate.hbm2ddl.auto" value="create-drop" />

--- a/jbpm-human-task/jbpm-human-task-jpa/src/test/resources/datasource.properties
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/test/resources/datasource.properties
@@ -15,6 +15,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 makeBaseDb=false
 testMarshalling=false
 txType=${maven.tx.type}

--- a/jbpm-persistence-jpa/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-persistence-jpa/src/test/filtered-resources/META-INF/persistence.xml
@@ -34,6 +34,7 @@
       <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
       <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
       <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
       
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
       <property name="hibernate.id.new_generator_mappings" value="false" />            
@@ -69,6 +70,7 @@
       <property name="hibernate.connection.url" value="${maven.jdbc.url}" />
       <property name="hibernate.connection.username" value="${maven.jdbc.username}" />
       <property name="hibernate.connection.password" value="${maven.jdbc.password}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
       <property name="hibernate.id.new_generator_mappings" value="false" />            

--- a/jbpm-persistence-jpa/src/test/filtered-resources/datasource.properties
+++ b/jbpm-persistence-jpa/src/test/filtered-resources/datasource.properties
@@ -15,6 +15,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 dbBaseDir=${project.build.directory}
 makeBaseDb=false
 testMarshalling=false

--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
@@ -197,7 +197,7 @@ public class PersistenceUtil {
             if( startServer ) { 
                 h2Server.start();
             }
-            for (String propertyName : new String[] { "url", "driverClassName" }) {
+            for (String propertyName : new String[] { "url", "driverClassName"}) {
                 pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));
             }
         } else {
@@ -212,6 +212,7 @@ public class PersistenceUtil {
                 pds.getDriverProperties().put("driverType", "4");
                 pds.getDriverProperties().put("serverName", dsProps.getProperty("serverName"));
                 pds.getDriverProperties().put("portNumber", dsProps.getProperty("portNumber"));
+                pds.getDriverProperties().put("currentSchema", dsProps.getProperty("defaultSchema"));
             } else if (driverClass.startsWith("com.microsoft")) {
                 for (String propertyName : new String[] { "serverName", "portNumber", "databaseName" }) {
                     pds.getDriverProperties().put(propertyName, dsProps.getProperty(propertyName));

--- a/jbpm-runtime-manager/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-runtime-manager/src/test/filtered-resources/META-INF/persistence.xml
@@ -58,6 +58,7 @@
       <property name="hibernate.show_sql" value="false" />
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
       
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
       <property name="hibernate.id.new_generator_mappings" value="false" />            

--- a/jbpm-runtime-manager/src/test/filtered-resources/datasource.properties
+++ b/jbpm-runtime-manager/src/test/filtered-resources/datasource.properties
@@ -15,6 +15,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 makeBaseDb=false
 testMarshalling=false
 txType=${maven.tx.type}

--- a/jbpm-services/jbpm-executor-cdi/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-services/jbpm-executor-cdi/src/test/filtered-resources/META-INF/persistence.xml
@@ -16,6 +16,7 @@
  
     <properties>
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <property name="hibernate.max_fetch_depth" value="3" />
       <property name="hibernate.hbm2ddl.auto" value="update" />
@@ -84,6 +85,7 @@
       <property name="hibernate.show_sql" value="false" />
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
       
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
       <property name="hibernate.id.new_generator_mappings" value="false" />            

--- a/jbpm-services/jbpm-executor-cdi/src/test/filtered-resources/datasource.properties
+++ b/jbpm-services/jbpm-executor-cdi/src/test/filtered-resources/datasource.properties
@@ -15,6 +15,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 makeBaseDb=false
 testMarshalling=false
 txType=${maven.tx.type}

--- a/jbpm-services/jbpm-executor/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-services/jbpm-executor/src/test/filtered-resources/META-INF/persistence.xml
@@ -16,6 +16,7 @@
  
     <properties>
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}" />
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <property name="hibernate.max_fetch_depth" value="3" />
       <property name="hibernate.hbm2ddl.auto" value="update" />
@@ -84,6 +85,7 @@
       <property name="hibernate.show_sql" value="false" />
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
       
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
       <property name="hibernate.id.new_generator_mappings" value="false" />            
@@ -150,6 +152,7 @@
       <property name="hibernate.show_sql" value="false" />
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
       
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
       <property name="hibernate.id.new_generator_mappings" value="false" />            

--- a/jbpm-services/jbpm-executor/src/test/filtered-resources/datasource.properties
+++ b/jbpm-services/jbpm-executor/src/test/filtered-resources/datasource.properties
@@ -15,6 +15,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 makeBaseDb=false
 testMarshalling=false
 txType=${maven.tx.type}

--- a/jbpm-services/pom.xml
+++ b/jbpm-services/pom.xml
@@ -36,7 +36,6 @@
         <maven.jdbc.username>sa</maven.jdbc.username>
         <maven.jdbc.password>sasa</maven.jdbc.password>
         <maven.jdbc.url>jdbc:h2:mem:test;MVCC=true</maven.jdbc.url>
-        <maven.jdbc.schema/>
     </properties>
 
 </project>

--- a/jbpm-test-coverage/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-test-coverage/src/test/filtered-resources/META-INF/persistence.xml
@@ -67,6 +67,7 @@
       <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
       <property name="hibernate.show_sql" value="false"/>
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
       <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
       <property name="hibernate.id.new_generator_mappings" value="false"/>

--- a/jbpm-test-coverage/src/test/filtered-resources/datasource.properties
+++ b/jbpm-test-coverage/src/test/filtered-resources/datasource.properties
@@ -16,6 +16,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 dbBaseDir=${basedir}
 makeBaseDb=false
 testMarshalling=false

--- a/jbpm-test/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-test/src/test/filtered-resources/META-INF/persistence.xml
@@ -62,6 +62,7 @@
             <property name="hibernate.hbm2ddl.auto" value="create" />
             <property name="hibernate.show_sql" value="false" />
             <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+            <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
             
             <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
             <property name="hibernate.id.new_generator_mappings" value="false" />            
@@ -86,6 +87,7 @@
             <property name="hibernate.hbm2ddl.auto" value="update" />
             <property name="hibernate.show_sql" value="false" />
             <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+            <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
             
             <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
             <property name="hibernate.id.new_generator_mappings" value="false" />            
@@ -135,6 +137,7 @@
             <property name="hibernate.hbm2ddl.auto" value="update" />
             <property name="hibernate.show_sql" value="false" />
             <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+            <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
 
             <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->      
             <property name="hibernate.id.new_generator_mappings" value="false" />  

--- a/jbpm-test/src/test/filtered-resources/datasource.properties
+++ b/jbpm-test/src/test/filtered-resources/datasource.properties
@@ -16,6 +16,7 @@ url=${maven.jdbc.url}
 serverName=${maven.jdbc.db.server}
 portNumber=${maven.jdbc.db.port}
 databaseName=${maven.jdbc.db.name}
+defaultSchema=${maven.jdbc.schema}
 dbBaseDir=${basedir}
 makeBaseDb=false
 testMarshalling=false


### PR DESCRIPTION
This is a replacement for this PR which had conficts: 
https://github.com/droolsjbpm/jbpm/pull/296

- Added default schema to persistence.xml and datasource.properties files. 
- Added default schema to datasource.properties handling (for DB2, other DB systems don't need it). 
- Fixed jbpm-services pom.xml - contained empty maven.jdbc.schema property.