### PR TITLE
JBPM-4790 IntermediateEventTest.testEventSubprocessSignalNested() fails on Sybase

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -585,7 +585,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 "sub-script",
                 "end-sub",
                 "Sub Sub End",
-                "Sub End ",
+                "Sub End",
                 "End"
         };
         runTestEventSubprocessSignal("BPMN2-EventSubprocessSignal-Nested.bpmn2", nodes);

--- a/jbpm-bpmn2/src/test/resources/BPMN2-EventSubprocessSignal-Nested.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-EventSubprocessSignal-Nested.bpmn2
@@ -32,7 +32,7 @@
       </bpmn2:subProcess>
       <bpmn2:sequenceFlow id="SequenceFlow_8" name="" sourceRef="_2-2" targetRef="_2-3"/>
 
-      <bpmn2:endEvent id="_2-3" name="Sub End " />
+      <bpmn2:endEvent id="_2-3" name="Sub End" />
     </bpmn2:subProcess>
     <bpmn2:sequenceFlow id="SequenceFlow_6" name="" sourceRef="_2" targetRef="_3"/>
 


### PR DESCRIPTION
- Removed trailing space from Sub End node name.