### PR TITLE
BZ-1234592 - Add reproducer

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/async/AsyncWIHOnOracleTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/regression/async/AsyncWIHOnOracleTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2015 JBoss Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.test.regression.async;
+
+import org.assertj.core.api.Assertions;
+import org.jbpm.executor.impl.wih.AsyncWorkItemHandler;
+import org.jbpm.persistence.jpa.hibernate.DisabledFollowOnLockOracle10gDialect;
+import org.jbpm.persistence.util.PersistenceUtil;
+import org.jbpm.test.JbpmAsyncJobTestCase;
+import org.junit.After;
+import org.junit.Test;
+import org.kie.api.executor.Command;
+import org.kie.api.executor.CommandContext;
+import org.kie.api.executor.ExecutionResults;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.WorkItemManager;
+import qa.tools.ikeeper.annotation.BZ;
+
+public class AsyncWIHOnOracleTest extends JbpmAsyncJobTestCase {
+
+    public static final String PROCESS = "org/jbpm/test/regression/async/AsyncWIHOnOracle.bpmn2";
+    public static final String PROCESS_ID = "org.jbpm.test.regression.async.AsyncWIHOnOracle";
+
+    private static final int EXECUTOR_THREADS = 2;
+    private static final int EXECUTOR_RETRIES = 2;
+    private static final int EXECUTOR_INTERVAL = 1;
+
+    public AsyncWIHOnOracleTest() {
+        super(EXECUTOR_THREADS, EXECUTOR_RETRIES, EXECUTOR_INTERVAL);
+    }
+
+    @Override
+    public void setUp() throws Exception {
+        String driverClassName = PersistenceUtil.getDatasourceProperties().getProperty("driverClassName");
+        if (driverClassName != null && driverClassName.contains("Oracle")) {
+            String hibernateDialect = DisabledFollowOnLockOracle10gDialect.class.getName();
+            addPersistenceProperty("hibernate.dialect", hibernateDialect);
+            logger.info("Using hibernate.dialect=" + hibernateDialect);
+        }
+        super.setUp();
+    }
+
+    @Test
+    @BZ("1234592")
+    public void testAsyncWIHExecutedMoreThanOnceOnOracle() throws InterruptedException {
+        KieSession ksession = createKSession(PROCESS);
+        WorkItemManager wim = ksession.getWorkItemManager();
+        wim.registerWorkItemHandler("async", new AsyncWorkItemHandler(getExecutorService(), CounterCommand.class.getName()));
+
+        ksession.startProcess(PROCESS_ID);
+
+        Thread.sleep(10000);
+
+        Assertions.assertThat(CounterCommand.getCounter()).as("The job has not been executed").isNotEqualTo(0);
+        Assertions.assertThat(CounterCommand.getCounter()).as("The job has been executed multiple times").isEqualTo(1);
+    }
+
+    @Override
+    @After
+    public void tearDown() {
+        try {
+            super.tearDown();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    public static class CounterCommand implements Command {
+
+        private static int counter = 0;
+
+        @Override
+        public ExecutionResults execute(CommandContext commandContext) throws Exception {
+            ++counter;
+            return new ExecutionResults();
+        }
+
+        public static int getCounter() {
+            return counter;
+        }
+
+    }
+
+}

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/async/AsyncWIHOnOracle.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/regression/async/AsyncWIHOnOracle.bpmn2
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_c6RK0CbTEeWPEpIpQcrLaQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="org.jbpm.test.regression.async.AsyncWIHOnOracle" drools:packageName="org.jbpm.test.regression.async" drools:version="1.0" name="AsyncWIHOnOracle" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_65806E05-1639-4863-9479-D26344AFEA3E</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:task id="_812B5D62-E0C4-479F-A2EC-66DF137AB297" drools:selectable="true" drools:taskName="async" name="">
+      <bpmn2:incoming>_65806E05-1639-4863-9479-D26344AFEA3E</bpmn2:incoming>
+      <bpmn2:outgoing>_FE3D1584-F278-4232-98DB-2203AF61E979</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_c6RK0SbTEeWPEpIpQcrLaQ">
+        <bpmn2:dataInput id="_812B5D62-E0C4-479F-A2EC-66DF137AB297_TaskNameInputX" name="TaskName"/>
+        <bpmn2:inputSet id="_c6RK0ibTEeWPEpIpQcrLaQ"/>
+        <bpmn2:outputSet id="_c6RK0ybTEeWPEpIpQcrLaQ"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_c6RK1CbTEeWPEpIpQcrLaQ">
+        <bpmn2:targetRef>_812B5D62-E0C4-479F-A2EC-66DF137AB297_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_c6RK1SbTEeWPEpIpQcrLaQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_c6RK1ibTEeWPEpIpQcrLaQ">async</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_c6RK1ybTEeWPEpIpQcrLaQ">_812B5D62-E0C4-479F-A2EC-66DF137AB297_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="_65806E05-1639-4863-9479-D26344AFEA3E" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_812B5D62-E0C4-479F-A2EC-66DF137AB297"/>
+    <bpmn2:endEvent id="_1E92E0F9-51CC-4D11-91AB-EB55214D79A1" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_FE3D1584-F278-4232-98DB-2203AF61E979</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_FE3D1584-F278-4232-98DB-2203AF61E979" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_812B5D62-E0C4-479F-A2EC-66DF137AB297" targetRef="_1E92E0F9-51CC-4D11-91AB-EB55214D79A1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_c6RK2CbTEeWPEpIpQcrLaQ">
+    <bpmndi:BPMNPlane id="_c6RK2SbTEeWPEpIpQcrLaQ" bpmnElement="org.jbpm.test.regression.async.AsyncWIHOnOracle">
+      <bpmndi:BPMNShape id="_c6RK2ibTEeWPEpIpQcrLaQ" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_c6RK2ybTEeWPEpIpQcrLaQ" bpmnElement="_812B5D62-E0C4-479F-A2EC-66DF137AB297">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_c6RK3CbTEeWPEpIpQcrLaQ" bpmnElement="_65806E05-1639-4863-9479-D26344AFEA3E">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_c6RK3SbTEeWPEpIpQcrLaQ" bpmnElement="_1E92E0F9-51CC-4D11-91AB-EB55214D79A1">
+        <dc:Bounds height="28.0" width="28.0" x="340.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_c6RK3ibTEeWPEpIpQcrLaQ" bpmnElement="_FE3D1584-F278-4232-98DB-2203AF61E979">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="354.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_c6RK3ybTEeWPEpIpQcrLaQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_1E92E0F9-51CC-4D11-91AB-EB55214D79A1" id="_c6Rx4CbTEeWPEpIpQcrLaQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_812B5D62-E0C4-479F-A2EC-66DF137AB297" id="_c6Rx4SbTEeWPEpIpQcrLaQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FE3D1584-F278-4232-98DB-2203AF61E979" id="_c6Rx4ibTEeWPEpIpQcrLaQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_c6Rx4ybTEeWPEpIpQcrLaQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_65806E05-1639-4863-9479-D26344AFEA3E" id="_c6Rx5CbTEeWPEpIpQcrLaQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_c6RK0CbTEeWPEpIpQcrLaQ</bpmn2:source>
+    <bpmn2:target>_c6RK0CbTEeWPEpIpQcrLaQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
@@ -152,6 +152,8 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
     protected List<TaskLifeCycleEventListener> customTaskListeners = new ArrayList<TaskLifeCycleEventListener>();
     protected Map<String, Object> customEnvironmentEntries = new HashMap<String, Object>();
 
+    private final Map<String, Object> persistenceProperties = new HashMap<String, Object>();
+
     /**
      * The most simple test case configuration:
      * <ul>
@@ -209,7 +211,7 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
         if (setupDataSource) {
             ds = setupPoolingDataSource();
             logger.debug("Data source configured with unique id {}", ds.getUniqueName());
-            emf = Persistence.createEntityManagerFactory(persistenceUnitName);
+            emf = Persistence.createEntityManagerFactory(persistenceUnitName, persistenceProperties);
         }
         cleanupSingletonSessionId();
 
@@ -242,6 +244,7 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
                     ds.close();
                     ds = null;
                 }
+                persistenceProperties.clear();
             }
         }
     }
@@ -931,6 +934,10 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
     
     public void addEnvironmentEntry(String name, Object value) {
     	customEnvironmentEntries.put(name, value);
+    }
+
+    public void addPersistenceProperty(String name, Object value) {
+        persistenceProperties.put(name, value);
     }
 
     protected static class TestWorkItemHandler implements WorkItemHandler {

--- a/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
+++ b/jbpm-test/src/main/java/org/jbpm/test/JbpmJUnitBaseTestCase.java
@@ -936,7 +936,7 @@ public abstract class JbpmJUnitBaseTestCase extends Assert {
     	customEnvironmentEntries.put(name, value);
     }
 
-    public void addPersistenceProperty(String name, Object value) {
+    public void setPersistenceProperty(String name, Object value) {
         persistenceProperties.put(name, value);
     }
 


### PR DESCRIPTION
Add simple reproducer for the following BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1234592

It needs to use special hibernate dialect DisabledFollowOnLockOracle10gDialect so I have also modified JbpmJUnitBaseTestCase to be able to set additional persistence unit properties.

Since the BZ mentioned above targets product version 6.2, this commit should be also cherry-picked to 6.3.x branch.