### PR TITLE
JBPM-4826 DB2 upgrade script bpms-6.0-to-6.1.sql doesn't change SessionInfo.id datatype properly if there are no sessions stored

### DIFF
--- a/jbpm-installer/db/upgrade-scripts/db2/bpms-6.0-to-6.1.sql
+++ b/jbpm-installer/db/upgrade-scripts/db2/bpms-6.0-to-6.1.sql
@@ -37,7 +37,7 @@ BEGIN
   DECLARE queryDrop VARCHAR(255);
   DECLARE queryAlterSessionInfo VARCHAR(255);
   DECLARE queryGenerateIdentity VARCHAR(255);
-  SET (counter) = (SELECT MAX(id) AS id FROM SessionInfo);
+  SET (counter) = (SELECT NVL(MAX(id), 0) AS id FROM SessionInfo);
   SET queryDrop = ('ALTER TABLE SessionInfo ALTER COLUMN id DROP IDENTITY');
   EXECUTE IMMEDIATE queryDrop;
   SET queryAlterSessionInfo = ('ALTER TABLE SessionInfo ALTER COLUMN id SET DATA TYPE BIGINT');

--- a/jbpm-installer/db/upgrade-scripts/db2/jbpm-6.1-to-6.2.sql
+++ b/jbpm-installer/db/upgrade-scripts/db2/jbpm-6.1-to-6.2.sql
@@ -37,7 +37,7 @@ BEGIN
   DECLARE queryDrop VARCHAR(255);
   DECLARE queryAlterSessionInfo VARCHAR(255);
   DECLARE queryGenerateIdentity VARCHAR(255);
-  SET (counter) = (SELECT MAX(id) AS id FROM SessionInfo);
+  SET (counter) = (SELECT NVL(MAX(id), 0) AS id FROM SessionInfo);
   SET queryDrop = ('ALTER TABLE SessionInfo ALTER COLUMN id DROP IDENTITY');
   EXECUTE IMMEDIATE queryDrop;
   SET queryAlterSessionInfo = ('ALTER TABLE SessionInfo ALTER COLUMN id SET DATA TYPE BIGINT');


### PR DESCRIPTION
- Added NVL function so the counter have always some value.