### PR TITLE
Fix for JBPM-4845. Split functionality of HumanTaskServiceProducer

### DIFF
--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskService.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskService.java
@@ -1,0 +1,22 @@
+package org.jbpm.services.cdi.test.humantaskservice;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Alternative;
+import javax.inject.Qualifier;
+
+/**
+ * Used to inject a custom HumanTaskServiceProducer.
+ * 
+ */
+@Alternative
+@Target({TYPE, FIELD, METHOD, PARAMETER})
+@Retention(RUNTIME)
+@Qualifier
+public @interface CustomHumanTaskService {
+
+}

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceProducer.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceProducer.java
@@ -1,0 +1,70 @@
+package org.jbpm.services.cdi.test.humantaskservice;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.inject.Alternative;
+import javax.enterprise.inject.Produces;
+import javax.inject.Qualifier;
+
+import org.drools.core.impl.EnvironmentFactory;
+import org.drools.persistence.jta.JtaTransactionManager;
+import org.jbpm.services.cdi.producer.HumanTaskServiceProducer;
+import org.jbpm.services.task.HumanTaskConfigurator;
+import org.jbpm.services.task.impl.command.CommandBasedTaskService;
+import org.jbpm.services.task.persistence.JPATaskPersistenceContextManager;
+import org.kie.api.runtime.Environment;
+import org.kie.api.runtime.EnvironmentName;
+
+/**
+ * 
+ * 
+ */
+public class CustomHumanTaskServiceProducer extends HumanTaskServiceProducer {
+
+    @Produces
+    @CustomHumanTaskService
+    @Override
+    public CommandBasedTaskService produceTaskService() {
+        return super.produceTaskService();
+    }
+    
+    @Override
+    protected void configureHumanTaskConfigurator(HumanTaskConfigurator configurator) {
+        Environment environment = EnvironmentFactory.newEnvironment();
+        environment.set(EnvironmentName.TASK_PERSISTENCE_CONTEXT_MANAGER, new CustomTaskPersistenceContextManager());
+        environment.set(EnvironmentName.TRANSACTION_MANAGER, new CustomTransactionManager());
+        super.configureHumanTaskConfigurator(configurator.environment(environment));
+    }
+    
+    public static class CustomTransactionManager extends JtaTransactionManager {
+        public CustomTransactionManager() {
+            super(null, null, null);
+        }
+    }
+    
+    
+    public static class CustomTaskPersistenceContextManager extends JPATaskPersistenceContextManager {
+        public CustomTaskPersistenceContextManager() {
+            super(EnvironmentFactory.newEnvironment());
+        }
+        
+        @Override
+        public void beginCommandScopedEntityManager() {
+            throw new CustomTaskPersistenceContextManagerInUse();
+        }
+    }
+    
+    /**
+     * Exception throw to show the CustomTaskPersistenceContextManager is in use.
+     */
+    @SuppressWarnings("serial")
+    public static class CustomTaskPersistenceContextManagerInUse extends RuntimeException {}
+
+}

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceTest.java
@@ -1,0 +1,163 @@
+/*
+      * Copyright 2014 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.services.cdi.test.humantaskservice;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePaths;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
+import org.jbpm.services.cdi.test.humantaskservice.CustomHumanTaskServiceProducer.CustomTaskPersistenceContextManagerInUse;
+import org.jbpm.services.task.commands.TaskCommand;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.task.TaskService;
+import org.kie.internal.command.Context;
+
+/**
+ * This test demonstrates subclassing the HumanTaskServiceProducer to inject 
+ * TaskPersistenceContextManager and TransactionManager instances into the environment.
+ * 
+ */
+@RunWith(Arquillian.class)
+public class CustomHumanTaskServiceTest extends AbstractKieServicesBaseTest {
+    
+    @Deployment()
+    public static Archive<?> createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, "jbpm-runtime-manager.jar")
+        		.addPackage("org.jbpm.services.task")
+                .addPackage("org.jbpm.services.task.wih") // work items org.jbpm.services.task.wih
+                .addPackage("org.jbpm.services.task.annotations")
+                .addPackage("org.jbpm.services.task.api")
+                .addPackage("org.jbpm.services.task.impl")
+                .addPackage("org.jbpm.services.task.events")
+                .addPackage("org.jbpm.services.task.exception")
+                .addPackage("org.jbpm.services.task.identity")
+                .addPackage("org.jbpm.services.task.factories")
+                .addPackage("org.jbpm.services.task.internals")
+                .addPackage("org.jbpm.services.task.internals.lifecycle")
+                .addPackage("org.jbpm.services.task.lifecycle.listeners")
+                .addPackage("org.jbpm.services.task.query")
+                .addPackage("org.jbpm.services.task.util")
+                .addPackage("org.jbpm.services.task.commands") // This should not be required here
+                .addPackage("org.jbpm.services.task.deadlines") // deadlines
+                .addPackage("org.jbpm.services.task.deadlines.notifications.impl")
+                .addPackage("org.jbpm.services.task.subtask")
+                .addPackage("org.jbpm.services.task.rule")
+                .addPackage("org.jbpm.services.task.rule.impl")
+                .addPackage("org.jbpm.services.task.audit.service")
+
+                .addPackage("org.kie.internal.runtime.manager")
+                .addPackage("org.kie.internal.runtime.manager.context")
+                .addPackage("org.kie.internal.runtime.manager.cdi.qualifier")
+                
+                .addPackage("org.jbpm.runtime.manager.impl")
+                .addPackage("org.jbpm.runtime.manager.impl.cdi")                               
+                .addPackage("org.jbpm.runtime.manager.impl.factory")
+                .addPackage("org.jbpm.runtime.manager.impl.jpa")
+                .addPackage("org.jbpm.runtime.manager.impl.manager")
+                .addPackage("org.jbpm.runtime.manager.impl.task")
+                .addPackage("org.jbpm.runtime.manager.impl.tx")
+                
+                .addPackage("org.jbpm.shared.services.api")
+                .addPackage("org.jbpm.shared.services.impl")
+                .addPackage("org.jbpm.shared.services.impl.tx")
+                
+                .addPackage("org.jbpm.kie.services.api")
+                .addPackage("org.jbpm.kie.services.impl")                
+                .addPackage("org.jbpm.kie.services.api.bpmn2")
+                .addPackage("org.jbpm.kie.services.impl.bpmn2")
+                .addPackage("org.jbpm.kie.services.impl.event.listeners")
+                .addPackage("org.jbpm.kie.services.impl.audit")
+                .addPackage("org.jbpm.kie.services.impl.form")
+                .addPackage("org.jbpm.kie.services.impl.form.provider")
+                
+                .addPackage("org.jbpm.services.cdi")
+                .addPackage("org.jbpm.services.cdi.impl")
+                .addPackage("org.jbpm.services.cdi.impl.form")
+                .addPackage("org.jbpm.services.cdi.impl.manager")
+                .addPackage("org.jbpm.services.cdi.producer")
+                .addPackage("org.jbpm.services.cdi.impl.security")
+                
+                .addPackage("org.jbpm.kie.services.test")
+                .addPackage("org.jbpm.services.cdi.test") // Identity Provider Test Impl here
+                .addPackage("org.jbpm.services.cdi.test.humantaskservice")
+                .addClass("org.jbpm.services.cdi.test.util.CDITestHelperNoTaskService")
+                .addClass("org.jbpm.services.cdi.test.util.CountDownDeploymentListenerCDIImpl")
+                .addClass("org.jbpm.kie.services.test.objects.CoundDownDeploymentListener")
+                .addAsResource("jndi.properties","jndi.properties")
+                .addAsManifestResource("META-INF/persistence.xml", ArchivePaths.create("persistence.xml"))
+                .addAsManifestResource("META-INF/Taskorm.xml", ArchivePaths.create("Taskorm.xml"))
+                .addAsManifestResource("META-INF/beans.xml", ArchivePaths.create("beans.xml"));
+
+    }
+
+    @Override
+	protected void configureServices() {
+		// do nothing here and let CDI configure services 
+	}
+    /*
+     * end of initialization code, tests start here
+     */
+
+    @Inject
+    private TaskService defaultTaskService;
+
+
+    @Inject
+    @CustomHumanTaskService
+    private TaskService customTaskService;
+
+    /**
+     * TestCommand should execute normally through the TaskService configured by the
+     * default HumanTaskServiceProducer.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testDefaultTaskService() throws Exception {
+        String result = defaultTaskService.execute(new TestCommand());
+        assertThat(result, is("Command Executed"));
+    }
+
+    /**
+     * The CustomHumanTaskService is configured with a TaskPersistenceContextManager
+     * implementation that throws an exception to prove that the custom environment
+     * is in use.
+     * 
+     * @throws Exception
+     */
+    @Test(expected=CustomTaskPersistenceContextManagerInUse.class)
+    public void testCustomTaskService() throws Exception {
+        customTaskService.execute(new TestCommand());
+    }
+
+    @SuppressWarnings("serial")
+    private static final class TestCommand extends TaskCommand<String> {
+        @Override
+        public String execute(Context context) {
+            return "Command Executed";
+        }
+    }
+}


### PR DESCRIPTION
Fix for JBPM-4845. Split functionality of HumanTaskServiceProducer.produceTaskService into 3 methods to allow easier reuse.