### PR TITLE
JBPM-4852 TaskService.complete() throws NullPointerException without …

### DIFF
--- a/jbpm-human-task/jbpm-human-task-workitems/src/main/java/org/jbpm/services/task/wih/ExternalTaskEventListener.java
+++ b/jbpm-human-task/jbpm-human-task-workitems/src/main/java/org/jbpm/services/task/wih/ExternalTaskEventListener.java
@@ -113,7 +113,11 @@ public class ExternalTaskEventListener implements TaskLifeCycleEventListener {
         if (processInstanceId <= 0) {
             return;
         }
-        RuntimeEngine runtime = getManager(task).getRuntimeEngine(ProcessInstanceIdContext.get(processInstanceId));
+        RuntimeManager manager = getManager(task);
+        if (manager == null) {
+            throw new RuntimeException("No RuntimeManager registered with identifier: " + task.getTaskData().getDeploymentId());
+        }
+        RuntimeEngine runtime = manager.getRuntimeEngine(ProcessInstanceIdContext.get(processInstanceId));
         KieSession session = runtime.getKieSession();
         if (session != null) {
             logger.debug(">> I've recieved an event for a known session (" + task.getTaskData().getProcessSessionId()+")");


### PR DESCRIPTION
…a meaningful message when a RuntimeManager with the deploymentId is not registered