### PR TITLE
Add GO delimiter to Sybase DLL scripts

### DIFF
--- a/jbpm-installer/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
+++ b/jbpm-installer/db/ddl-scripts/sybase/sybase-jbpm-schema.sql
@@ -10,6 +10,7 @@
         TaskData_Attachments_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table AuditTaskImpl (
         id numeric(19,0) identity not null,
@@ -31,6 +32,7 @@
         workItemId numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table BAMTaskSummary (
         pk numeric(19,0) identity not null,
@@ -46,6 +48,7 @@
         OPTLOCK int null,
         primary key (pk)
     ) lock datarows
+    go
 
     create table BooleanExpression (
         id numeric(19,0) identity not null,
@@ -54,12 +57,14 @@
         Escalation_Constraints_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Content (
         id numeric(19,0) identity not null,
         content image null,
         primary key (id)
     ) lock datarows
+    go
 
     create table ContextMappingInfo (
         mappingId numeric(19,0) identity not null,
@@ -69,6 +74,7 @@
         OPTLOCK int null,
         primary key (mappingId)
     ) lock datarows
+    go
 
     create table CorrelationKeyInfo (
         keyId numeric(19,0) identity not null,
@@ -77,6 +83,7 @@
         OPTLOCK int null,
         primary key (keyId)
     ) lock datarows
+    go
 
     create table CorrelationPropertyInfo (
         propertyId numeric(19,0) identity not null,
@@ -86,6 +93,7 @@
         correlationKey_keyId numeric(19,0) null,
         primary key (propertyId)
     ) lock datarows
+    go
 
     create table Deadline (
         id numeric(19,0) identity not null,
@@ -95,11 +103,13 @@
         Deadlines_EndDeadLine_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Delegation_delegates (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table DeploymentStore (
         id numeric(19,0) identity not null,
@@ -110,6 +120,7 @@
         updateDate datetime null,
         primary key (id)
     ) lock datarows
+    go
 
     create table ErrorInfo (
         id numeric(19,0) identity not null,
@@ -119,6 +130,7 @@
         REQUEST_ID numeric(19,0) not null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Escalation (
         id numeric(19,0) identity not null,
@@ -126,11 +138,13 @@
         Deadline_Escalation_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table EventTypes (
         InstanceId numeric(19,0) not null,
         element varchar(255) null
     ) lock datarows
+    go
 
     create table I18NText (
         id numeric(19,0) identity not null,
@@ -148,6 +162,7 @@
         Deadline_Documentation_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table NodeInstanceLog (
         id numeric(19,0) identity not null,
@@ -164,6 +179,7 @@
         workItemId numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Notification (
         DTYPE varchar(31) not null,
@@ -172,16 +188,19 @@
         Escalation_Notifications_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Notification_BAs (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table Notification_Recipients (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table Notification_email_header (
         Notification_id numeric(19,0) not null,
@@ -189,37 +208,44 @@
         mapkey varchar(255) not null,
         primary key (Notification_id, mapkey)
     ) lock datarows
+    go
 
     create table OrganizationalEntity (
         DTYPE varchar(31) not null,
         id varchar(255) not null,
         primary key (id)
     ) lock datarows
+    go
 
     create table PeopleAssignments_BAs (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table PeopleAssignments_ExclOwners (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table PeopleAssignments_PotOwners (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table PeopleAssignments_Recipients (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table PeopleAssignments_Stakeholders (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table ProcessInstanceInfo (
         InstanceId numeric(19,0) identity not null,
@@ -232,6 +258,7 @@
         OPTLOCK int null,
         primary key (InstanceId)
     ) lock datarows
+    go
 
     create table ProcessInstanceLog (
         id numeric(19,0) identity not null,
@@ -251,17 +278,20 @@
         status int null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Reassignment (
         id numeric(19,0) identity not null,
         Escalation_Reassignments_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Reassignment_potentialOwners (
         task_id numeric(19,0) not null,
         entity_id varchar(255) not null
     ) lock datarows
+    go
 
     create table RequestInfo (
         id numeric(19,0) identity not null,
@@ -278,6 +308,7 @@
         timestamp datetime null,
         primary key (id)
     ) lock datarows
+    go
 
     create table SessionInfo (
         id numeric(19,0) identity not null,
@@ -287,6 +318,7 @@
         OPTLOCK int null,
         primary key (id)
     ) lock datarows
+    go
 
     create table Task (
         id numeric(19,0) identity not null,
@@ -327,6 +359,7 @@
         createdBy_id varchar(255) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table TaskDef (
         id numeric(19,0) identity not null,
@@ -334,6 +367,7 @@
         priority int not null,
         primary key (id)
     ) lock datarows
+    go
 
     create table TaskEvent (
         id numeric(19,0) identity not null,
@@ -347,6 +381,7 @@
         workItemId numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table TaskVariableImpl (
         id numeric(19,0) identity not null,
@@ -359,6 +394,7 @@
         value varchar(255) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table VariableInstanceLog (
         id numeric(19,0) identity not null,
@@ -372,6 +408,7 @@
         variableInstanceId varchar(255) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table WorkItemInfo (
         workItemId numeric(19,0) identity not null,
@@ -383,6 +420,7 @@
         workItemByteArray image null,
         primary key (workItemId)
     ) lock datarows
+    go
 
     create table email_header (
         id numeric(19,0) identity not null,
@@ -393,6 +431,7 @@
         subject varchar(255) null,
         primary key (id)
     ) lock datarows
+    go
 
     create table task_comment (
         id numeric(19,0) identity not null,
@@ -402,234 +441,282 @@
         TaskData_Comments_Id numeric(19,0) null,
         primary key (id)
     ) lock datarows
+    go
 
-    alter table Attachment 
-        add constraint FK1C93543D937BFB5 
-        foreign key (attachedBy_id) 
+    alter table Attachment
+        add constraint FK1C93543D937BFB5
+        foreign key (attachedBy_id)
         references OrganizationalEntity
+    go
 
-    alter table Attachment 
-        add constraint FK1C9354333CA892A 
-        foreign key (TaskData_Attachments_Id) 
+    alter table Attachment
+        add constraint FK1C9354333CA892A
+        foreign key (TaskData_Attachments_Id)
         references Task
+    go
 
-    alter table BooleanExpression 
-        add constraint FKE3D208C06C97C90E 
-        foreign key (Escalation_Constraints_Id) 
+    alter table BooleanExpression
+        add constraint FKE3D208C06C97C90E
+        foreign key (Escalation_Constraints_Id)
         references Escalation
+    go
 
-    alter table CorrelationPropertyInfo 
-        add constraint FK761452A5D87156ED 
-        foreign key (correlationKey_keyId) 
+    alter table CorrelationPropertyInfo
+        add constraint FK761452A5D87156ED
+        foreign key (correlationKey_keyId)
         references CorrelationKeyInfo
+    go
 
-    alter table Deadline 
-        add constraint FK21DF3E78A9FE0EF4 
-        foreign key (Deadlines_StartDeadLine_Id) 
+    alter table Deadline
+        add constraint FK21DF3E78A9FE0EF4
+        foreign key (Deadlines_StartDeadLine_Id)
         references Task
+    go
 
-    alter table Deadline 
-        add constraint FK21DF3E78695E4DDB 
-        foreign key (Deadlines_EndDeadLine_Id) 
+    alter table Deadline
+        add constraint FK21DF3E78695E4DDB
+        foreign key (Deadlines_EndDeadLine_Id)
         references Task
+    go
 
-    alter table Delegation_delegates 
-        add constraint FK47485D5772B3A123 
-        foreign key (entity_id) 
+    alter table Delegation_delegates
+        add constraint FK47485D5772B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table Delegation_delegates 
-        add constraint FK47485D57786553A5 
-        foreign key (task_id) 
+    alter table Delegation_delegates
+        add constraint FK47485D57786553A5
+        foreign key (task_id)
         references Task
+    go
 
-    alter table DeploymentStore 
+    alter table DeploymentStore
         add constraint UK_DeploymentStore_1 unique (DEPLOYMENT_ID)
+    go
 
-    alter table ErrorInfo 
-        add constraint FK8B1186B6724A467 
-        foreign key (REQUEST_ID) 
+    alter table ErrorInfo
+        add constraint FK8B1186B6724A467
+        foreign key (REQUEST_ID)
         references RequestInfo
+    go
 
-    alter table Escalation 
-        add constraint FK67B2C6B5D1E5CC1 
-        foreign key (Deadline_Escalation_Id) 
+    alter table Escalation
+        add constraint FK67B2C6B5D1E5CC1
+        foreign key (Deadline_Escalation_Id)
         references Deadline
+    go
 
-    alter table EventTypes 
-        add constraint FKB0E5621F7665489A 
-        foreign key (InstanceId) 
+    alter table EventTypes
+        add constraint FKB0E5621F7665489A
+        foreign key (InstanceId)
         references ProcessInstanceInfo
+    go
 
-    alter table I18NText 
-        add constraint FK2349686BF4ACCD69 
-        foreign key (Task_Subjects_Id) 
+    alter table I18NText
+        add constraint FK2349686BF4ACCD69
+        foreign key (Task_Subjects_Id)
         references Task
+    go
 
-    alter table I18NText 
-        add constraint FK2349686B424B187C 
-        foreign key (Task_Names_Id) 
+    alter table I18NText
+        add constraint FK2349686B424B187C
+        foreign key (Task_Names_Id)
         references Task
+    go
 
-    alter table I18NText 
-        add constraint FK2349686BAB648139 
-        foreign key (Task_Descriptions_Id) 
+    alter table I18NText
+        add constraint FK2349686BAB648139
+        foreign key (Task_Descriptions_Id)
         references Task
+    go
 
-    alter table I18NText 
-        add constraint FK2349686BB340A2AA 
-        foreign key (Reassignment_Documentation_Id) 
+    alter table I18NText
+        add constraint FK2349686BB340A2AA
+        foreign key (Reassignment_Documentation_Id)
         references Reassignment
+    go
 
-    alter table I18NText 
-        add constraint FK2349686BF0CDED35 
-        foreign key (Notification_Subjects_Id) 
+    alter table I18NText
+        add constraint FK2349686BF0CDED35
+        foreign key (Notification_Subjects_Id)
         references Notification
+    go
 
-    alter table I18NText 
-        add constraint FK2349686BCC03ED3C 
-        foreign key (Notification_Names_Id) 
+    alter table I18NText
+        add constraint FK2349686BCC03ED3C
+        foreign key (Notification_Names_Id)
         references Notification
+    go
 
-    alter table I18NText 
-        add constraint FK2349686B77C1C08A 
-        foreign key (Notification_Documentation_Id) 
+    alter table I18NText
+        add constraint FK2349686B77C1C08A
+        foreign key (Notification_Documentation_Id)
         references Notification
+    go
 
-    alter table I18NText 
-        add constraint FK2349686B18DDFE05 
-        foreign key (Notification_Descriptions_Id) 
+    alter table I18NText
+        add constraint FK2349686B18DDFE05
+        foreign key (Notification_Descriptions_Id)
         references Notification
+    go
 
-    alter table I18NText 
-        add constraint FK2349686B78AF072A 
-        foreign key (Deadline_Documentation_Id) 
+    alter table I18NText
+        add constraint FK2349686B78AF072A
+        foreign key (Deadline_Documentation_Id)
         references Deadline
+    go
 
-    alter table Notification 
-        add constraint FK2D45DD0BC0C0F29C 
-        foreign key (Escalation_Notifications_Id) 
+    alter table Notification
+        add constraint FK2D45DD0BC0C0F29C
+        foreign key (Escalation_Notifications_Id)
         references Escalation
+    go
 
-    alter table Notification_BAs 
-        add constraint FK2DD68EE072B3A123 
-        foreign key (entity_id) 
+    alter table Notification_BAs
+        add constraint FK2DD68EE072B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table Notification_BAs 
-        add constraint FK2DD68EE093F2090B 
-        foreign key (task_id) 
+    alter table Notification_BAs
+        add constraint FK2DD68EE093F2090B
+        foreign key (task_id)
         references Notification
+    go
 
-    alter table Notification_Recipients 
-        add constraint FK98FD214E72B3A123 
-        foreign key (entity_id) 
+    alter table Notification_Recipients
+        add constraint FK98FD214E72B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table Notification_Recipients 
-        add constraint FK98FD214E93F2090B 
-        foreign key (task_id) 
+    alter table Notification_Recipients
+        add constraint FK98FD214E93F2090B
+        foreign key (task_id)
         references Notification
+    go
 
-    alter table Notification_email_header 
+    alter table Notification_email_header
         add constraint UK_F30FE3446CEA0510 unique (emailHeaders_id)
+    go
 
-    alter table Notification_email_header 
-        add constraint FKF30FE3448BED1339 
-        foreign key (emailHeaders_id) 
+    alter table Notification_email_header
+        add constraint FKF30FE3448BED1339
+        foreign key (emailHeaders_id)
         references email_header
+    go
 
-    alter table Notification_email_header 
-        add constraint FKF30FE3443E3E97EB 
-        foreign key (Notification_id) 
+    alter table Notification_email_header
+        add constraint FKF30FE3443E3E97EB
+        foreign key (Notification_id)
         references Notification
+    go
 
-    alter table PeopleAssignments_BAs 
-        add constraint FK9D8CF4EC72B3A123 
-        foreign key (entity_id) 
+    alter table PeopleAssignments_BAs
+        add constraint FK9D8CF4EC72B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table PeopleAssignments_BAs 
-        add constraint FK9D8CF4EC786553A5 
-        foreign key (task_id) 
+    alter table PeopleAssignments_BAs
+        add constraint FK9D8CF4EC786553A5
+        foreign key (task_id)
         references Task
+    go
 
-    alter table PeopleAssignments_ExclOwners 
-        add constraint FKC77B97E472B3A123 
-        foreign key (entity_id) 
+    alter table PeopleAssignments_ExclOwners
+        add constraint FKC77B97E472B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table PeopleAssignments_ExclOwners 
-        add constraint FKC77B97E4786553A5 
-        foreign key (task_id) 
+    alter table PeopleAssignments_ExclOwners
+        add constraint FKC77B97E4786553A5
+        foreign key (task_id)
         references Task
+    go
 
-    alter table PeopleAssignments_PotOwners 
-        add constraint FK1EE418D72B3A123 
-        foreign key (entity_id) 
+    alter table PeopleAssignments_PotOwners
+        add constraint FK1EE418D72B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table PeopleAssignments_PotOwners 
-        add constraint FK1EE418D786553A5 
-        foreign key (task_id) 
+    alter table PeopleAssignments_PotOwners
+        add constraint FK1EE418D786553A5
+        foreign key (task_id)
         references Task
+    go
 
-    alter table PeopleAssignments_Recipients 
-        add constraint FKC6F615C272B3A123 
-        foreign key (entity_id) 
+    alter table PeopleAssignments_Recipients
+        add constraint FKC6F615C272B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table PeopleAssignments_Recipients 
-        add constraint FKC6F615C2786553A5 
-        foreign key (task_id) 
+    alter table PeopleAssignments_Recipients
+        add constraint FKC6F615C2786553A5
+        foreign key (task_id)
         references Task
+    go
 
-    alter table PeopleAssignments_Stakeholders 
-        add constraint FK482F79D572B3A123 
-        foreign key (entity_id) 
+    alter table PeopleAssignments_Stakeholders
+        add constraint FK482F79D572B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table PeopleAssignments_Stakeholders 
-        add constraint FK482F79D5786553A5 
-        foreign key (task_id) 
+    alter table PeopleAssignments_Stakeholders
+        add constraint FK482F79D5786553A5
+        foreign key (task_id)
         references Task
+    go
 
-    alter table Reassignment 
-        add constraint FK724D056062A1E871 
-        foreign key (Escalation_Reassignments_Id) 
+    alter table Reassignment
+        add constraint FK724D056062A1E871
+        foreign key (Escalation_Reassignments_Id)
         references Escalation
+    go
 
-    alter table Reassignment_potentialOwners 
-        add constraint FK90B59CFF72B3A123 
-        foreign key (entity_id) 
+    alter table Reassignment_potentialOwners
+        add constraint FK90B59CFF72B3A123
+        foreign key (entity_id)
         references OrganizationalEntity
+    go
 
-    alter table Reassignment_potentialOwners 
-        add constraint FK90B59CFF35D2FEE0 
-        foreign key (task_id) 
+    alter table Reassignment_potentialOwners
+        add constraint FK90B59CFF35D2FEE0
+        foreign key (task_id)
         references Reassignment
+    go
 
-    alter table Task 
-        add constraint FK27A9A53C55C806 
-        foreign key (taskInitiator_id) 
+    alter table Task
+        add constraint FK27A9A53C55C806
+        foreign key (taskInitiator_id)
         references OrganizationalEntity
+    go
 
-    alter table Task 
-        add constraint FK27A9A5B723BE8B 
-        foreign key (actualOwner_id) 
+    alter table Task
+        add constraint FK27A9A5B723BE8B
+        foreign key (actualOwner_id)
         references OrganizationalEntity
+    go
 
-    alter table Task 
-        add constraint FK27A9A55427E8F1 
-        foreign key (createdBy_id) 
+    alter table Task
+        add constraint FK27A9A55427E8F1
+        foreign key (createdBy_id)
         references OrganizationalEntity
+    go
 
-    alter table task_comment 
-        add constraint FK61F475A57A3215D9 
-        foreign key (addedBy_id) 
+    alter table task_comment
+        add constraint FK61F475A57A3215D9
+        foreign key (addedBy_id)
         references OrganizationalEntity
+    go
 
-    alter table task_comment 
-        add constraint FK61F475A5F510CB46 
-        foreign key (TaskData_Comments_Id) 
+    alter table task_comment
+        add constraint FK61F475A5F510CB46
+        foreign key (TaskData_Comments_Id)
         references Task
+    go


### PR DESCRIPTION
It allows you to create all tables in a single batch now.

The commit also fixes line separators since CRLFs (Windows) were used before.