### PR TITLE
[6.3.x] Reduce output when running tests

### DIFF
--- a/jbpm-installer/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-installer/src/test/filtered-resources/META-INF/persistence.xml
@@ -32,7 +32,7 @@
       <property name="hibernate.max_fetch_depth" value="3"/>
       <!-- No value for hbm2ddl.auto, because tests manage DDL themselves. -->
       <property name="hibernate.hbm2ddl.auto" value=""/>
-      <property name="hibernate.show_sql" value="true"/>
+      <property name="hibernate.show_sql" value="false"/>
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
 
@@ -103,7 +103,7 @@
     <properties>
       <property name="hibernate.max_fetch_depth" value="3"/>
       <property name="hibernate.hbm2ddl.auto" value="validate"/>
-      <property name="hibernate.show_sql" value="true"/>
+      <property name="hibernate.show_sql" value="false"/>
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
 
@@ -187,7 +187,7 @@
       <property name="hibernate.max_fetch_depth" value="3"/>
       <!-- No value for hbm2ddl.auto, because tests manage DDL themselves. -->
       <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
-      <property name="hibernate.show_sql" value="true"/>
+      <property name="hibernate.show_sql" value="false"/>
 
       <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
 

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/TestPersistenceContext.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/TestPersistenceContext.java
@@ -44,6 +44,8 @@ import org.kie.internal.task.api.model.InternalPeopleAssignments;
 import org.kie.internal.task.api.model.InternalTaskData;
 
 import bitronix.tm.resource.jdbc.PoolingDataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Central context that hides persistence from tests, so there is no need to work with persistence in the tests
@@ -51,6 +53,7 @@ import bitronix.tm.resource.jdbc.PoolingDataSource;
  */
 public final class TestPersistenceContext {
 
+    private static final Logger logger = LoggerFactory.getLogger(TestPersistenceContext.class);
     private HashMap<String, Object> context;
     private EntityManagerFactory entityManagerFactory;
     private JtaTransactionManager transactionManager;
@@ -104,10 +107,10 @@ public final class TestPersistenceContext {
         try {
             for (File script : sqlScripts) {
                 if (type == null || script.getName().startsWith(type)) {
-                    System.out.println("Executing script " + script.getName());
+                    logger.debug("Executing script {}", script.getName());
                     final List<String> scriptCommands = SQLScriptUtil.getCommandsFromScript(script, databaseType);
                     for (String command : scriptCommands) {
-                        System.out.println(command);
+                        logger.debug(command);
                         final PreparedStatement statement;
                         if (databaseType == DatabaseType.SQLSERVER || databaseType == DatabaseType.SQLSERVER2008) {
                             statement = connection.prepareStatement(

--- a/jbpm-installer/src/test/resources/logback-test.xml
+++ b/jbpm-installer/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <!-- %l lowers performance -->
+      <!--<pattern>%d [%t] %-5p %l%n  %m%n</pattern>-->
+      <pattern>%d [%t|%C] %-5p %m%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="bitronix.tm" level="error"/>
+  <logger name="org.hibernate" level="warn"/>
+  <logger name="org.hibernate.tool.hbm2ddl" level="error"/>
+  <logger name="org.hibernate.ejb.internal" level="error"/>
+
+  <root level="info">
+    <appender-ref ref="consoleAppender" />
+  </root>
+
+</configuration>

--- a/jbpm-test-coverage/src/main/java/org/jbpm/test/jobexec/UserCommandWithCallback.java
+++ b/jbpm-test-coverage/src/main/java/org/jbpm/test/jobexec/UserCommandWithCallback.java
@@ -20,12 +20,16 @@ import org.kie.api.executor.Command;
 import org.kie.api.executor.CommandContext;
 import org.kie.api.executor.ExecutionResults;
 import org.kie.api.runtime.process.WorkItem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class UserCommandWithCallback implements Command {
 
+    private static final Logger logger = LoggerFactory.getLogger(UserCommandWithCallback.class);
+
     public ExecutionResults execute(CommandContext ctx) {
-        System.out.println("[INFO] Command executed on executor with " + ctx.getData());
+        logger.debug("Command executed on executor with {}", ctx.getData());
 
         WorkItem workItem = (WorkItem) ctx.getData("workItem");
         User user = (User) workItem.getParameter("UserIn");
@@ -38,7 +42,7 @@ public class UserCommandWithCallback implements Command {
 
         double item = 0;
         for (int i = 0; i < 99; i++) {
-            System.out.println("[INFO] User item:" + item);
+            logger.debug("User item: {}", item);
             item++;
         }
         return executionResults;

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/ParalellLoopTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/ParalellLoopTest.java
@@ -27,12 +27,15 @@ import org.kie.api.runtime.manager.RuntimeManager;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.task.TaskService;
 import org.kie.api.task.model.TaskSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is a sample file to launch a process.
  */
 public class ParalellLoopTest extends JbpmTestCase {
 
+  private static final Logger logger = LoggerFactory.getLogger(ParalellLoopTest.class);
   TaskService taskService;
 
   @Test
@@ -50,7 +53,7 @@ public class ParalellLoopTest extends JbpmTestCase {
 
     for (int i = 0; i < 20; i++) {
 
-      System.out.println(">>> Loop: " + i);
+      logger.debug(">>> Loop: {}", i);
 
       assertNodeTriggered(processInstance.getId(), "ApproveMary");
       assertNodeTriggered(processInstance.getId(), "ApproveJohn");
@@ -90,7 +93,7 @@ public class ParalellLoopTest extends JbpmTestCase {
 
     for (int i = 0; i < 20; i++) {
 
-      System.out.println(">>> Loop: " + i);
+      logger.debug(">>> Loop: {}", i);
 
 
       assertNodeTriggered(processInstance.getId(), "ApproveMary");
@@ -131,7 +134,7 @@ public class ParalellLoopTest extends JbpmTestCase {
 
     for (int i = 0; i < 20; i++) {
 
-      System.out.println(">>> Loop: " + i);
+      logger.debug(">>> Loop: {}", i);
 
       complete("mary", "Approve");
       complete("john", "Reject");
@@ -165,7 +168,7 @@ public class ParalellLoopTest extends JbpmTestCase {
 
     for (int i = 0; i < 20; i++) {
 
-      System.out.println(">>> Loop: " + i);
+      logger.debug(">>> Loop: {}", i);
 
       complete("john", "Approve");
       complete("mary", "Reject");
@@ -199,7 +202,7 @@ public class ParalellLoopTest extends JbpmTestCase {
 
     for (int i = 0; i < 20; i++) {
 
-      System.out.println(">>> Loop: " + i);
+      logger.debug(">>> Loop: {}", i);
 
       assertNodeTriggered(processInstance.getId(), "ApproveMary");
       assertNodeTriggered(processInstance.getId(), "ApproveJohn");
@@ -252,14 +255,14 @@ public class ParalellLoopTest extends JbpmTestCase {
 
     List<TaskSummary> list = taskService.getTasksAssignedAsPotentialOwner(user, "en-UK");
     TaskSummary task = list.get(0);
-    System.out.println("complete task");
-    System.out.println("- " + user + " is executing task " + task.getName());
+    logger.debug("complete task");
+    logger.debug("- {} is executing task {}", user, task.getName());
     taskService.start(task.getId(), user);
 
     Map<String, Object> map = new HashMap<String, Object>();
     map.put("OUTCOME", outcome);
     taskService.complete(task.getId(), user, map);
-    System.out.println("- " + user + " executed task " + task.getName());
+    logger.debug("- {} executed task {}", user, task.getName());
   }
 
   public ParalellLoopTest() {


### PR DESCRIPTION
 * these changes reduce the test output
   by 70 %

Same changes already merged into master. These are only test-related changes, so I believe it is safe to backport them into 6.3.x.