### PR TITLE
JBPM-4886 - Resetting timer cycle in a running workflow process

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2015 JBoss by Red Hat.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.test.functional.timer;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.jbpm.process.instance.command.UpdateTimerCommand;
+import org.jbpm.test.JbpmTestCase;
+import org.jbpm.test.listener.CountDownProcessEventListener;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.kie.api.event.process.DefaultProcessEventListener;
+import org.kie.api.event.process.ProcessStartedEvent;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.manager.RuntimeEngine;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test for UpdateTimmerCommand
+ */
+public class TimerUpdateTest extends JbpmTestCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(TimerPersistenceTest.class);
+
+    private static final String TIMER_FILE = "org/jbpm/test/functional/timer/UpdateTimer.bpmn2";
+    private static final String PROCESS_NAME = "UpdateTimer";
+    private static final String TIMER_NAME = "Timer";
+
+    private static final String START_TIMER_FILE = "org/jbpm/test/functional/timer/UpdateStartTimer.bpmn2";
+    private static final String START_PROCESS_NAME = "UpdateStartTimer";
+    private static final String START_TIMER_NAME = "StartTimer";
+
+    private static final String BOUNDARY_TIMER_FILE = "org/jbpm/test/functional/timer/UpdateBoundaryTimer.bpmn2";
+    private static final String BOUNDARY_PROCESS_NAME = "UpdateBoundaryTimer";
+    private static final String BOUNDARY_TIMER_NAME = "BoundaryTimer";
+
+    private RuntimeEngine runtimeEngine;
+    private KieSession kieSession;
+
+    private static final String TIMER_FIRED_TEXT = "Hello Adele";
+    private static final String TIMER_FIRED_TIME_PROP = "Time Adele";
+
+    @Before
+    public void setup() {
+        runtimeEngine = null;
+        kieSession = null;
+        System.clearProperty(TIMER_FIRED_TEXT);
+        System.clearProperty(TIMER_FIRED_TIME_PROP);
+    }
+
+    @Test(timeout = 30000)
+    public void updateTimerLongerDelayTest() {
+        CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(TIMER_NAME, 1);
+        //delay is set for 5s
+        setProcessScenario(TIMER_FILE);
+
+        kieSession.addEventListener(countDownListener);
+        final List<Long> list = new ArrayList<Long>();
+        kieSession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                list.add(event.getProcessInstance().getId());
+            }
+        });
+
+        Assertions.assertThat(list).isEmpty();
+        long id = kieSession.startProcess(PROCESS_NAME).getId();
+        long startTime = System.currentTimeMillis();
+        Assertions.assertThat(list).isNotEmpty();
+        //set delay to 8s
+        kieSession.execute(new UpdateTimerCommand(id, TIMER_NAME, 8));
+
+        countDownListener.waitTillCompleted();
+        Assertions.assertThat(timerHasFired()).isTrue();
+        long firedTime = timerFiredTime();
+        long timeDifference = Math.abs(firedTime - startTime - 8000);
+        logger.info("Start time: " + startTime + ", fired time: " + firedTime + ", difference: " + (firedTime-startTime));
+        Assertions.assertThat(timeDifference).isLessThan(500);
+
+        Assertions.assertThat(kieSession.getProcessInstance(id)).isNull();
+    }
+
+    @Test(timeout = 30000)
+    public void updateTimerShortherDelayTest() {
+        CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(TIMER_NAME, 1);
+        //delay is set for 5s
+        setProcessScenario(TIMER_FILE);
+
+        kieSession.addEventListener(countDownListener);
+        final List<Long> list = new ArrayList<Long>();
+        kieSession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                list.add(event.getProcessInstance().getId());
+            }
+        });
+
+        Assertions.assertThat(list).isEmpty();
+        long id = kieSession.startProcess(PROCESS_NAME).getId();
+        long startTime = System.currentTimeMillis();
+        Assertions.assertThat(list).isNotEmpty();
+        //set delay to 3s
+        kieSession.execute(new UpdateTimerCommand(id, TIMER_NAME, 3));
+
+        countDownListener.waitTillCompleted();
+        Assertions.assertThat(timerHasFired()).isTrue();
+        long firedTime = timerFiredTime();
+        long timeDifference = Math.abs(firedTime - startTime - 3000);
+        logger.info("Start time: " + startTime + ", fired time: " + firedTime + ", difference: " + (firedTime-startTime));
+        Assertions.assertThat(timeDifference).isLessThan(500);
+
+        Assertions.assertThat(kieSession.getProcessInstance(id)).isNull();
+    }
+
+    @Test(timeout = 30000)
+    public void updateTimerBeforeDelayTest() {
+        CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(TIMER_NAME, 1);
+        //delay is set for 5s
+        setProcessScenario(TIMER_FILE);
+
+        kieSession.addEventListener(countDownListener);
+        final List<Long> list = new ArrayList<Long>();
+        kieSession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                list.add(event.getProcessInstance().getId());
+            }
+        });
+
+        Assertions.assertThat(list).isEmpty();
+        long id = kieSession.startProcess(PROCESS_NAME).getId();
+        long startTime = System.currentTimeMillis();
+        Assertions.assertThat(list).isNotEmpty();
+        //set delay on time that passed -> expected that timer fired immediately
+        kieSession.execute(new UpdateTimerCommand(id, TIMER_NAME, -5));
+
+        countDownListener.waitTillCompleted();
+        Assertions.assertThat(timerHasFired()).isTrue();
+        long firedTime = timerFiredTime();
+        long timeDifference = Math.abs(firedTime - startTime);
+        logger.info("Start time: " + startTime + ", fired time: " + firedTime + ", difference: " + (firedTime-startTime));
+        Assertions.assertThat(timeDifference).isLessThan(500);
+
+        Assertions.assertThat(kieSession.getProcessInstance(id)).isNull();
+    }
+
+    /*
+      Test is ignored, because UpdateTimerCommand didn't work.
+    */
+    @Ignore
+    @Test(timeout = 30000)
+    public void updateStartTimerTest() {
+        CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(START_TIMER_NAME, 3);
+        //period is set for 5s and repeat limit is unset
+        setProcessScenario(START_TIMER_FILE);
+        kieSession.addEventListener(countDownListener);
+
+        ProcessInstance pi = kieSession.startProcess(START_PROCESS_NAME);
+        long startTime = System.currentTimeMillis();
+
+        final List<Long> list = new ArrayList<Long>();
+        kieSession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                list.add(event.getProcessInstance().getId());
+            }
+        });
+        Assertions.assertThat(list).isEmpty();
+        //set period to 2s and repeat limit on 3
+        kieSession.execute(new UpdateTimerCommand(pi.getId(), START_TIMER_NAME, 2, 3));
+        countDownListener.waitTillCompleted();
+
+        Assertions.assertThat(timerFiredCount()).isEqualTo(3);
+        long firedTime = timerFiredTime();
+        //expected time is 4s
+        long timeDifference = Math.abs(firedTime - startTime - 4000);
+        logger.info("Start time: " + startTime + ", fired time: " + firedTime + ", difference: " + (firedTime-startTime));
+        Assertions.assertThat(timeDifference).isLessThan(1000);
+    }
+
+    /*
+      Test is ignored, because UpdateTimerCommand didn't work.
+    */
+    @Ignore
+    @Test(timeout=30000)
+    public void updateStartTimertLaterTest() throws Exception {
+        CountDownProcessEventListener beforeUpdateCountDownListener = new CountDownProcessEventListener(START_TIMER_NAME, 2);
+        CountDownProcessEventListener afterUpdateCountDownListener = new CountDownProcessEventListener(START_TIMER_NAME, 3);
+        //period is set for 5s and repeat limit is unset
+        setProcessScenario(START_TIMER_FILE);
+        kieSession.addEventListener(beforeUpdateCountDownListener);
+
+        ProcessInstance pi = kieSession.startProcess(START_PROCESS_NAME);
+        long startTime = System.currentTimeMillis();
+
+        final List<Long> list = new ArrayList<Long>();
+        kieSession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                list.add(event.getProcessInstance().getId());
+            }
+        });
+
+        Assertions.assertThat(list).isEmpty();
+        beforeUpdateCountDownListener.waitTillCompleted();
+        Assertions.assertThat(list.size()).isEqualTo(2);
+        long halfTime = timerFiredTime();
+        Assertions.assertThat(timerFiredCount()).isEqualTo(2);
+        logger.info("Start time: " + startTime + ", half time: " + halfTime + ", difference: " + (halfTime-startTime));
+
+        kieSession.removeEventListener(beforeUpdateCountDownListener);
+        kieSession.addEventListener(afterUpdateCountDownListener);
+        //set period to 2s and repeat limit on 3
+        kieSession.execute(new UpdateTimerCommand(pi.getId(), START_TIMER_NAME, 2, 3));
+
+        afterUpdateCountDownListener.waitTillCompleted();
+        long finalTime = timerFiredTime();
+        Assertions.assertThat(list.size()).isEqualTo(5);
+        Assertions.assertThat(timerFiredCount()).isEqualTo(5);
+        logger.info("Half time: " + halfTime + ", final time: " + finalTime + ", difference: " + (finalTime-halfTime));
+        logger.info("Start time: " + startTime + ", final time: " + finalTime + ", difference: " + (finalTime-startTime));
+        //expected time is 5s + 6s (before update + after update)
+        long timeDifference = Math.abs(finalTime-startTime-5000-6000);
+        Assertions.assertThat(timeDifference).isLessThan(1000);
+    }
+
+    /*
+      Test is ignored, because UpdateTimerCommand didn't work.
+    */
+    @Ignore
+    @Test(timeout = 30000)
+    public void updateBoundaryTimerTest() {
+        CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(BOUNDARY_TIMER_NAME, 1);
+        //timer is set for long duration (100s)
+        setProcessScenario(BOUNDARY_TIMER_FILE);
+
+        final List<Long> list = new ArrayList<Long>();
+        kieSession.addEventListener(new DefaultProcessEventListener() {
+            @Override
+            public void beforeProcessStarted(ProcessStartedEvent event) {
+                list.add(event.getProcessInstance().getId());
+            }
+        });
+
+        Assertions.assertThat(list).isEmpty();
+        long id = kieSession.startProcess(BOUNDARY_PROCESS_NAME).getId();
+        long startTime = System.currentTimeMillis();
+        Assertions.assertThat(list).isNotEmpty();
+        //set timer delay to 3s
+        kieSession.execute(new UpdateTimerCommand(id, BOUNDARY_TIMER_NAME, 3));
+
+        countDownListener.waitTillCompleted();
+        Assertions.assertThat(timerHasFired()).isTrue();
+        long firedTime = timerFiredTime();
+        long timeDifference = Math.abs(firedTime - startTime - 3000);
+        logger.info("Start time: " + startTime + ", fired time: " + firedTime + ", difference: " + (firedTime-startTime));
+        Assertions.assertThat(timeDifference).isLessThan(1000);
+
+        Assertions.assertThat(kieSession.getProcessInstance(id)).isNull();
+    }
+
+    private void setProcessScenario(String file) {
+        createRuntimeManager(file);
+        runtimeEngine = getRuntimeEngine();
+        kieSession = runtimeEngine.getKieSession();
+        Assertions.assertThat(kieSession).isNotNull();
+    }
+
+    private boolean timerHasFired() {
+        String hasFired = System.getProperty(TIMER_FIRED_TEXT);
+        return hasFired != null;
+    }
+
+    private int timerFiredCount() {
+        String timerFiredCount = System.getProperty(TIMER_FIRED_TEXT);
+        if( timerFiredCount == null ) {
+           return 0;
+        }
+        return Integer.parseInt(timerFiredCount);
+    }
+
+    private long timerFiredTime() {
+        String timerFiredTime = System.getProperty(TIMER_FIRED_TIME_PROP);
+        if( timerFiredTime == null ) {
+           return 0;
+        }
+        return Long.parseLong(timerFiredTime);
+    }
+
+}

--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/timer/TimerUpdateTest.java
@@ -17,18 +17,17 @@ package org.jbpm.test.functional.timer;
 
 import java.util.ArrayList;
 import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.jbpm.process.instance.command.UpdateTimerCommand;
 import org.jbpm.test.JbpmTestCase;
 import org.jbpm.test.listener.CountDownProcessEventListener;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.kie.api.event.process.DefaultProcessEventListener;
 import org.kie.api.event.process.ProcessStartedEvent;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
-import org.kie.api.runtime.process.ProcessInstance;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,6 +49,7 @@ public class TimerUpdateTest extends JbpmTestCase {
     private static final String BOUNDARY_TIMER_FILE = "org/jbpm/test/functional/timer/UpdateBoundaryTimer.bpmn2";
     private static final String BOUNDARY_PROCESS_NAME = "UpdateBoundaryTimer";
     private static final String BOUNDARY_TIMER_NAME = "BoundaryTimer";
+    private static final String BOUNDARY_TIMER_ATTACHED_TO_NAME = "User";
 
     private RuntimeEngine runtimeEngine;
     private KieSession kieSession;
@@ -160,91 +160,7 @@ public class TimerUpdateTest extends JbpmTestCase {
 
         Assertions.assertThat(kieSession.getProcessInstance(id)).isNull();
     }
-
-    /*
-      Test is ignored, because UpdateTimerCommand didn't work.
-    */
-    @Ignore
-    @Test(timeout = 30000)
-    public void updateStartTimerTest() {
-        CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(START_TIMER_NAME, 3);
-        //period is set for 5s and repeat limit is unset
-        setProcessScenario(START_TIMER_FILE);
-        kieSession.addEventListener(countDownListener);
-
-        ProcessInstance pi = kieSession.startProcess(START_PROCESS_NAME);
-        long startTime = System.currentTimeMillis();
-
-        final List<Long> list = new ArrayList<Long>();
-        kieSession.addEventListener(new DefaultProcessEventListener() {
-            @Override
-            public void beforeProcessStarted(ProcessStartedEvent event) {
-                list.add(event.getProcessInstance().getId());
-            }
-        });
-        Assertions.assertThat(list).isEmpty();
-        //set period to 2s and repeat limit on 3
-        kieSession.execute(new UpdateTimerCommand(pi.getId(), START_TIMER_NAME, 2, 3));
-        countDownListener.waitTillCompleted();
-
-        Assertions.assertThat(timerFiredCount()).isEqualTo(3);
-        long firedTime = timerFiredTime();
-        //expected time is 4s
-        long timeDifference = Math.abs(firedTime - startTime - 4000);
-        logger.info("Start time: " + startTime + ", fired time: " + firedTime + ", difference: " + (firedTime-startTime));
-        Assertions.assertThat(timeDifference).isLessThan(1000);
-    }
-
-    /*
-      Test is ignored, because UpdateTimerCommand didn't work.
-    */
-    @Ignore
-    @Test(timeout=30000)
-    public void updateStartTimertLaterTest() throws Exception {
-        CountDownProcessEventListener beforeUpdateCountDownListener = new CountDownProcessEventListener(START_TIMER_NAME, 2);
-        CountDownProcessEventListener afterUpdateCountDownListener = new CountDownProcessEventListener(START_TIMER_NAME, 3);
-        //period is set for 5s and repeat limit is unset
-        setProcessScenario(START_TIMER_FILE);
-        kieSession.addEventListener(beforeUpdateCountDownListener);
-
-        ProcessInstance pi = kieSession.startProcess(START_PROCESS_NAME);
-        long startTime = System.currentTimeMillis();
-
-        final List<Long> list = new ArrayList<Long>();
-        kieSession.addEventListener(new DefaultProcessEventListener() {
-            @Override
-            public void beforeProcessStarted(ProcessStartedEvent event) {
-                list.add(event.getProcessInstance().getId());
-            }
-        });
-
-        Assertions.assertThat(list).isEmpty();
-        beforeUpdateCountDownListener.waitTillCompleted();
-        Assertions.assertThat(list.size()).isEqualTo(2);
-        long halfTime = timerFiredTime();
-        Assertions.assertThat(timerFiredCount()).isEqualTo(2);
-        logger.info("Start time: " + startTime + ", half time: " + halfTime + ", difference: " + (halfTime-startTime));
-
-        kieSession.removeEventListener(beforeUpdateCountDownListener);
-        kieSession.addEventListener(afterUpdateCountDownListener);
-        //set period to 2s and repeat limit on 3
-        kieSession.execute(new UpdateTimerCommand(pi.getId(), START_TIMER_NAME, 2, 3));
-
-        afterUpdateCountDownListener.waitTillCompleted();
-        long finalTime = timerFiredTime();
-        Assertions.assertThat(list.size()).isEqualTo(5);
-        Assertions.assertThat(timerFiredCount()).isEqualTo(5);
-        logger.info("Half time: " + halfTime + ", final time: " + finalTime + ", difference: " + (finalTime-halfTime));
-        logger.info("Start time: " + startTime + ", final time: " + finalTime + ", difference: " + (finalTime-startTime));
-        //expected time is 5s + 6s (before update + after update)
-        long timeDifference = Math.abs(finalTime-startTime-5000-6000);
-        Assertions.assertThat(timeDifference).isLessThan(1000);
-    }
-
-    /*
-      Test is ignored, because UpdateTimerCommand didn't work.
-    */
-    @Ignore
+    
     @Test(timeout = 30000)
     public void updateBoundaryTimerTest() {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener(BOUNDARY_TIMER_NAME, 1);
@@ -258,13 +174,14 @@ public class TimerUpdateTest extends JbpmTestCase {
                 list.add(event.getProcessInstance().getId());
             }
         });
+        kieSession.addEventListener(countDownListener);
 
         Assertions.assertThat(list).isEmpty();
         long id = kieSession.startProcess(BOUNDARY_PROCESS_NAME).getId();
         long startTime = System.currentTimeMillis();
         Assertions.assertThat(list).isNotEmpty();
         //set timer delay to 3s
-        kieSession.execute(new UpdateTimerCommand(id, BOUNDARY_TIMER_NAME, 3));
+        kieSession.execute(new UpdateTimerCommand(id, BOUNDARY_TIMER_ATTACHED_TO_NAME, 3));
 
         countDownListener.waitTillCompleted();
         Assertions.assertThat(timerHasFired()).isTrue();

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/timer/UpdateBoundaryTimer.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/timer/UpdateBoundaryTimer.bpmn2
@@ -1,0 +1,247 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_fNVg4J_5EeW7QvlyDK06tQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="__444E8B09-6477-4C76-9547-2091AC259912_SkippableInputXItem" structureRef="Object"/>
+  <bpmn2:process id="UpdateBoundaryTimer" drools:packageName="org.jbpm" drools:version="1.0" name="UpdateBoundaryTimer" isExecutable="true">
+    <bpmn2:startEvent id="_A8309CC0-D2A6-4F43-9E0C-58F0C1516F66" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="Start">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_8D14149E-EBDD-4366-947F-30A07CF4D5F7</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:scriptTask id="_65586AE6-9CE0-4622-AF69-827E444D4373" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Script" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Script]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_A5B81D53-E59D-474A-AFBC-9801ED8F77CF</bpmn2:incoming>
+      <bpmn2:outgoing>_017D7BCF-A96C-47DB-8264-A4F38934052F</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Hello Adele");
+String val = System.getProperty("Hello Adele");
+System.setProperty("Time Adele", String.valueOf(System.currentTimeMillis()));
+int valInt = 1;
+if( val != null ) {
+  valInt = Integer.parseInt(val) + 1;
+}
+System.setProperty("Hello Adele", String.valueOf(valInt));]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:endEvent id="_54211DE6-07FD-4371-88DC-7E0BCB3B8ACE" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="End">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_88AAF9DA-5ED0-4DAC-8DC7-473783104F14</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_fNVg4Z_5EeW7QvlyDK06tQ"/>
+    </bpmn2:endEvent>
+    <bpmn2:userTask id="_444E8B09-6477-4C76-9547-2091AC259912" drools:selectable="true" drools:scriptFormat="http://www.java.com/java" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="User">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[User]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_8D14149E-EBDD-4366-947F-30A07CF4D5F7</bpmn2:incoming>
+      <bpmn2:outgoing>_88AAF9DA-5ED0-4DAC-8DC7-473783104F14</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_fNVg4p_5EeW7QvlyDK06tQ">
+        <bpmn2:dataInput id="_444E8B09-6477-4C76-9547-2091AC259912_TaskNameInputX" name="TaskName"/>
+        <bpmn2:dataInput id="_444E8B09-6477-4C76-9547-2091AC259912_SkippableInputX" drools:dtype="Object" itemSubjectRef="__444E8B09-6477-4C76-9547-2091AC259912_SkippableInputXItem" name="Skippable"/>
+        <bpmn2:inputSet id="_fNVg45_5EeW7QvlyDK06tQ">
+          <bpmn2:dataInputRefs>_444E8B09-6477-4C76-9547-2091AC259912_SkippableInputX</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_444E8B09-6477-4C76-9547-2091AC259912_TaskNameInputX</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_fNVg5J_5EeW7QvlyDK06tQ"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_fNVg5Z_5EeW7QvlyDK06tQ">
+        <bpmn2:targetRef>_444E8B09-6477-4C76-9547-2091AC259912_TaskNameInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_fNVg5p_5EeW7QvlyDK06tQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_fNVg55_5EeW7QvlyDK06tQ">HumanTask</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_fNVg6J_5EeW7QvlyDK06tQ">_444E8B09-6477-4C76-9547-2091AC259912_TaskNameInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_fNVg6Z_5EeW7QvlyDK06tQ">
+        <bpmn2:targetRef>_444E8B09-6477-4C76-9547-2091AC259912_SkippableInputX</bpmn2:targetRef>
+        <bpmn2:assignment id="_fNVg6p_5EeW7QvlyDK06tQ">
+          <bpmn2:from xsi:type="bpmn2:tFormalExpression" id="_fNVg65_5EeW7QvlyDK06tQ">true</bpmn2:from>
+          <bpmn2:to xsi:type="bpmn2:tFormalExpression" id="_fNVg7J_5EeW7QvlyDK06tQ">_444E8B09-6477-4C76-9547-2091AC259912_SkippableInputX</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:userTask>
+    <bpmn2:sequenceFlow id="_8D14149E-EBDD-4366-947F-30A07CF4D5F7" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_A8309CC0-D2A6-4F43-9E0C-58F0C1516F66" targetRef="_444E8B09-6477-4C76-9547-2091AC259912"/>
+    <bpmn2:sequenceFlow id="_88AAF9DA-5ED0-4DAC-8DC7-473783104F14" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_444E8B09-6477-4C76-9547-2091AC259912" targetRef="_54211DE6-07FD-4371-88DC-7E0BCB3B8ACE"/>
+    <bpmn2:sequenceFlow id="_A5B81D53-E59D-474A-AFBC-9801ED8F77CF" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_5EBEAE38-41CC-4CA6-B337-E997F735134F" targetRef="_65586AE6-9CE0-4622-AF69-827E444D4373"/>
+    <bpmn2:sequenceFlow id="_017D7BCF-A96C-47DB-8264-A4F38934052F" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_65586AE6-9CE0-4622-AF69-827E444D4373" targetRef="_4075D93B-F125-42E5-A696-E8147FBF2ABA"/>
+    <bpmn2:endEvent id="_4075D93B-F125-42E5-A696-E8147FBF2ABA" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="EndAfterScript">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[EndAfterScript]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[EndAfterScript]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_017D7BCF-A96C-47DB-8264-A4F38934052F</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_fNVg7Z_5EeW7QvlyDK06tQ"/>
+    </bpmn2:endEvent>
+    <bpmn2:boundaryEvent id="_5EBEAE38-41CC-4CA6-B337-E997F735134F" drools:selectable="true" drools:boundaryca="false" drools:dockerinfo="68.0^70.0|" color:background-color="#f5deb3" color:border-color="#a0522d" color:color="#000000" name="BoundaryTimer" attachedToRef="_444E8B09-6477-4C76-9547-2091AC259912" cancelActivity="false">
+      <bpmn2:outgoing>_A5B81D53-E59D-474A-AFBC-9801ED8F77CF</bpmn2:outgoing>
+      <bpmn2:timerEventDefinition id="_fNVg7p_5EeW7QvlyDK06tQ">
+        <bpmn2:timeDuration xsi:type="bpmn2:tFormalExpression" id="_fNVg75_5EeW7QvlyDK06tQ">PT100S</bpmn2:timeDuration>
+      </bpmn2:timerEventDefinition>
+    </bpmn2:boundaryEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_fNVg8J_5EeW7QvlyDK06tQ">
+    <bpmndi:BPMNPlane id="_fNVg8Z_5EeW7QvlyDK06tQ" bpmnElement="UpdateBoundaryTimer">
+      <bpmndi:BPMNShape id="_fNVg8p_5EeW7QvlyDK06tQ" bpmnElement="_A8309CC0-D2A6-4F43-9E0C-58F0C1516F66">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_fNVg85_5EeW7QvlyDK06tQ" bpmnElement="_65586AE6-9CE0-4622-AF69-827E444D4373">
+        <dc:Bounds height="80.0" width="100.0" x="420.0" y="210.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_fNVg9J_5EeW7QvlyDK06tQ" bpmnElement="_54211DE6-07FD-4371-88DC-7E0BCB3B8ACE">
+        <dc:Bounds height="28.0" width="28.0" x="600.0" y="105.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_fNVg9Z_5EeW7QvlyDK06tQ" bpmnElement="_444E8B09-6477-4C76-9547-2091AC259912">
+        <dc:Bounds height="80.0" width="100.0" x="255.0" y="141.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_fNVg9p_5EeW7QvlyDK06tQ" bpmnElement="_8D14149E-EBDD-4366-947F-30A07CF4D5F7">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="181.0"/>
+        <di:waypoint xsi:type="dc:Point" x="305.0" y="181.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_fNVg95_5EeW7QvlyDK06tQ" bpmnElement="_88AAF9DA-5ED0-4DAC-8DC7-473783104F14">
+        <di:waypoint xsi:type="dc:Point" x="305.0" y="181.0"/>
+        <di:waypoint xsi:type="dc:Point" x="614.0" y="119.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_fNVg-J_5EeW7QvlyDK06tQ" bpmnElement="_A5B81D53-E59D-474A-AFBC-9801ED8F77CF">
+        <di:waypoint xsi:type="dc:Point" x="329.0" y="221.0"/>
+        <di:waypoint xsi:type="dc:Point" x="470.0" y="250.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_fNVg-Z_5EeW7QvlyDK06tQ" bpmnElement="_017D7BCF-A96C-47DB-8264-A4F38934052F">
+        <di:waypoint xsi:type="dc:Point" x="470.0" y="250.0"/>
+        <di:waypoint xsi:type="dc:Point" x="614.0" y="250.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_fNVg-p_5EeW7QvlyDK06tQ" bpmnElement="_4075D93B-F125-42E5-A696-E8147FBF2ABA">
+        <dc:Bounds height="28.0" width="28.0" x="600.0" y="236.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_fNVg-5_5EeW7QvlyDK06tQ" bpmnElement="_5EBEAE38-41CC-4CA6-B337-E997F735134F">
+        <dc:Bounds height="30.0" width="30.0" x="314.0" y="206.0"/>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_fNVg_J_5EeW7QvlyDK06tQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_8D14149E-EBDD-4366-947F-30A07CF4D5F7" id="_fNVg_Z_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_65586AE6-9CE0-4622-AF69-827E444D4373" id="_fNVg_p_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_444E8B09-6477-4C76-9547-2091AC259912" id="_fNVg_5_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ResourceParameters xsi:type="bpsim:ResourceParameters">
+              <bpsim:Availability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="8.0"/>
+              </bpsim:Availability>
+              <bpsim:Quantity xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="1.0"/>
+              </bpsim:Quantity>
+            </bpsim:ResourceParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A8309CC0-D2A6-4F43-9E0C-58F0C1516F66" id="_fNVhAJ_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A5B81D53-E59D-474A-AFBC-9801ED8F77CF" id="_fNVhAZ_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_017D7BCF-A96C-47DB-8264-A4F38934052F" id="_fNWH8J_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4075D93B-F125-42E5-A696-E8147FBF2ABA" id="_fNWH8Z_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5EBEAE38-41CC-4CA6-B337-E997F735134F" id="_fNWH8p_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_54211DE6-07FD-4371-88DC-7E0BCB3B8ACE" id="_fNWH85_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_88AAF9DA-5ED0-4DAC-8DC7-473783104F14" id="_fNWH9J_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_fNVg4J_5EeW7QvlyDK06tQ</bpmn2:source>
+    <bpmn2:target>_fNVg4J_5EeW7QvlyDK06tQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/timer/UpdateStartTimer.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/timer/UpdateStartTimer.bpmn2
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_zk3d4J_9EeW7QvlyDK06tQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="UpdateStartTimer" drools:packageName="org.jbpm" drools:version="1.0" name="UpdateStartTimer" isExecutable="true">
+    <bpmn2:scriptTask id="_BD59DFF1-33FF-43F6-A6B2-4F343B3E609A" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Script" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Script]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_6A8567EB-3388-4F13-8FDA-ACF81EFEF59B</bpmn2:incoming>
+      <bpmn2:outgoing>_8135536F-62A9-4662-ADA8-803A115DF2A8</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Hello Adele" + " - SystemTime: "+ System.currentTimeMillis());
+String val = System.getProperty("Hello Adele");
+System.setProperty("Time Adele", String.valueOf(System.currentTimeMillis()));
+int valInt = 1;
+if( val != null ) {
+  valInt = Integer.parseInt(val) + 1;
+}
+System.setProperty("Hello Adele", String.valueOf(valInt));]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_8135536F-62A9-4662-ADA8-803A115DF2A8" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_BD59DFF1-33FF-43F6-A6B2-4F343B3E609A" targetRef="_FF6DFE56-C17C-4DAE-9137-F9DB954C79DF"/>
+    <bpmn2:startEvent id="_BB770105-8688-45F8-A94F-54618248DE69" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="StartTimer">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[StartTimer]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[StartTimer]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_6A8567EB-3388-4F13-8FDA-ACF81EFEF59B</bpmn2:outgoing>
+      <bpmn2:timerEventDefinition id="_zk3d4Z_9EeW7QvlyDK06tQ">
+        <bpmn2:timeCycle xsi:type="bpmn2:tFormalExpression" id="_zk3d4p_9EeW7QvlyDK06tQ">R/PT5S</bpmn2:timeCycle>
+      </bpmn2:timerEventDefinition>
+    </bpmn2:startEvent>
+    <bpmn2:sequenceFlow id="_6A8567EB-3388-4F13-8FDA-ACF81EFEF59B" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_BB770105-8688-45F8-A94F-54618248DE69" targetRef="_BD59DFF1-33FF-43F6-A6B2-4F343B3E609A"/>
+    <bpmn2:endEvent id="_FF6DFE56-C17C-4DAE-9137-F9DB954C79DF" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="End">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_8135536F-62A9-4662-ADA8-803A115DF2A8</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_ZpB90qVqEeWgAfaXRa6moQ"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_zk3d45_9EeW7QvlyDK06tQ">
+    <bpmndi:BPMNPlane id="_zk3d5J_9EeW7QvlyDK06tQ" bpmnElement="UpdateStartTimer">
+      <bpmndi:BPMNShape id="_zk3d5Z_9EeW7QvlyDK06tQ" bpmnElement="_BD59DFF1-33FF-43F6-A6B2-4F343B3E609A">
+        <dc:Bounds height="80.0" width="100.0" x="270.0" y="135.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_zk3d5p_9EeW7QvlyDK06tQ" bpmnElement="_8135536F-62A9-4662-ADA8-803A115DF2A8">
+        <di:waypoint xsi:type="dc:Point" x="320.0" y="175.0"/>
+        <di:waypoint xsi:type="dc:Point" x="487.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_zk3d55_9EeW7QvlyDK06tQ" bpmnElement="_BB770105-8688-45F8-A94F-54618248DE69">
+        <dc:Bounds height="30.0" width="30.0" x="135.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_zk3d6J_9EeW7QvlyDK06tQ" bpmnElement="_6A8567EB-3388-4F13-8FDA-ACF81EFEF59B">
+        <di:waypoint xsi:type="dc:Point" x="150.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="320.0" y="175.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_zk3d6Z_9EeW7QvlyDK06tQ" bpmnElement="_FF6DFE56-C17C-4DAE-9137-F9DB954C79DF">
+        <dc:Bounds height="28.0" width="28.0" x="473.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_zk3d6p_9EeW7QvlyDK06tQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_BB770105-8688-45F8-A94F-54618248DE69" id="_zk3d65_9EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FF6DFE56-C17C-4DAE-9137-F9DB954C79DF" id="_zk3d7J_9EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_6A8567EB-3388-4F13-8FDA-ACF81EFEF59B" id="_zk3d7Z_9EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_BD59DFF1-33FF-43F6-A6B2-4F343B3E609A" id="_zk3d7p_9EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_8135536F-62A9-4662-ADA8-803A115DF2A8" id="_zk3d75_9EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_zk3d4J_9EeW7QvlyDK06tQ</bpmn2:source>
+    <bpmn2:target>_zk3d4J_9EeW7QvlyDK06tQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/timer/UpdateTimer.bpmn2
+++ b/jbpm-test-coverage/src/test/resources/org/jbpm/test/functional/timer/UpdateTimer.bpmn2
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_KD63IJ_5EeW7QvlyDK06tQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:process id="UpdateTimer" drools:packageName="org.jbpm" drools:version="1.0" name="UpdateTimer" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="Start">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Start]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_5BDA4F30-9EA6-412B-9F64-C8A7075DD4A4</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:intermediateCatchEvent id="_5D9C36B9-DA3A-4371-A68E-CED5A8DD4271" drools:selectable="true" drools:boundaryca="" color:background-color="#f5deb3" color:border-color="#a0522d" color:color="#000000" name="Timer">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Timer]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_5BDA4F30-9EA6-412B-9F64-C8A7075DD4A4</bpmn2:incoming>
+      <bpmn2:outgoing>_0BE3574E-C433-4A0C-B93B-D63083DFFE7B</bpmn2:outgoing>
+      <bpmn2:timerEventDefinition id="_KD63IZ_5EeW7QvlyDK06tQ">
+        <bpmn2:timeDuration xsi:type="bpmn2:tFormalExpression" id="_KD63Ip_5EeW7QvlyDK06tQ">PT5S</bpmn2:timeDuration>
+      </bpmn2:timerEventDefinition>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:scriptTask id="_EB3FD9FD-2D3D-4490-BB86-8833407E3445" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Script" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Script]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_0BE3574E-C433-4A0C-B93B-D63083DFFE7B</bpmn2:incoming>
+      <bpmn2:outgoing>_392E750C-23E3-46FC-A340-DA4C40D062E2</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Hello Adele");
+String val = System.getProperty("Hello Adele");
+System.setProperty("Time Adele", String.valueOf(System.currentTimeMillis()));
+int valInt = 1;
+if( val != null ) {
+  valInt = Integer.parseInt(val) + 1;
+}
+System.setProperty("Hello Adele", String.valueOf(valInt));]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_0BE3574E-C433-4A0C-B93B-D63083DFFE7B" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_5D9C36B9-DA3A-4371-A68E-CED5A8DD4271" targetRef="_EB3FD9FD-2D3D-4490-BB86-8833407E3445"/>
+    <bpmn2:sequenceFlow id="_392E750C-23E3-46FC-A340-DA4C40D062E2" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_EB3FD9FD-2D3D-4490-BB86-8833407E3445" targetRef="_5ABD07CB-656A-4B3E-88FB-48D07C6C12FE"/>
+    <bpmn2:endEvent id="_5ABD07CB-656A-4B3E-88FB-48D07C6C12FE" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="End">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[End]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_392E750C-23E3-46FC-A340-DA4C40D062E2</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_KD63I5_5EeW7QvlyDK06tQ"/>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_5BDA4F30-9EA6-412B-9F64-C8A7075DD4A4" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_5D9C36B9-DA3A-4371-A68E-CED5A8DD4271"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_KD63JJ_5EeW7QvlyDK06tQ">
+    <bpmndi:BPMNPlane id="_KD63JZ_5EeW7QvlyDK06tQ" bpmnElement="UpdateTimer">
+      <bpmndi:BPMNShape id="_KD63Jp_5EeW7QvlyDK06tQ" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_KD63J5_5EeW7QvlyDK06tQ" bpmnElement="_5D9C36B9-DA3A-4371-A68E-CED5A8DD4271">
+        <dc:Bounds height="30.0" width="30.0" x="210.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_KD63KJ_5EeW7QvlyDK06tQ" bpmnElement="_EB3FD9FD-2D3D-4490-BB86-8833407E3445">
+        <dc:Bounds height="80.0" width="100.0" x="285.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_KD63KZ_5EeW7QvlyDK06tQ" bpmnElement="_0BE3574E-C433-4A0C-B93B-D63083DFFE7B">
+        <di:waypoint xsi:type="dc:Point" x="225.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="335.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_KD63Kp_5EeW7QvlyDK06tQ" bpmnElement="_392E750C-23E3-46FC-A340-DA4C40D062E2">
+        <di:waypoint xsi:type="dc:Point" x="335.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="449.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_KD63K5_5EeW7QvlyDK06tQ" bpmnElement="_5ABD07CB-656A-4B3E-88FB-48D07C6C12FE">
+        <dc:Bounds height="28.0" width="28.0" x="435.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_KD63LJ_5EeW7QvlyDK06tQ" bpmnElement="_5BDA4F30-9EA6-412B-9F64-C8A7075DD4A4">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="225.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_KD63LZ_5EeW7QvlyDK06tQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5ABD07CB-656A-4B3E-88FB-48D07C6C12FE" id="_KD63Lp_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5D9C36B9-DA3A-4371-A68E-CED5A8DD4271" id="_KD63L5_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_392E750C-23E3-46FC-A340-DA4C40D062E2" id="_KD63MJ_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_0BE3574E-C433-4A0C-B93B-D63083DFFE7B" id="_KD63MZ_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5BDA4F30-9EA6-412B-9F64-C8A7075DD4A4" id="_KD63Mp_5EeW7QvlyDK06tQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EB3FD9FD-2D3D-4490-BB86-8833407E3445" id="_KD63M5_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_KD63NJ_5EeW7QvlyDK06tQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_KD63IJ_5EeW7QvlyDK06tQ</bpmn2:source>
+    <bpmn2:target>_KD63IJ_5EeW7QvlyDK06tQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>


### PR DESCRIPTION
replaces https://github.com/droolsjbpm/jbpm/pull/364 as this incorporates https://github.com/droolsjbpm/jbpm/pull/364 and fix for ignored test. 

start timer tests have been removed as they are not in scope as UpdateTimerCommand is only for active process instances and start timer event is not on active process instance as it starts the instance by timer  event. That means when process instance is started timer has already fired.