### PR TITLE
GUVNOR-2173 - Asset Oracle: Change Impact prediction

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompilationTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/CompilationTest.java
@@ -1,0 +1,103 @@
+package org.jbpm.bpmn2;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.compiler.compiler.AnalysisResult;
+import org.drools.compiler.compiler.ReturnValueDescr;
+import org.drools.compiler.lang.descr.ActionDescr;
+import org.drools.compiler.lang.descr.BaseDescr;
+import org.drools.compiler.rule.builder.PackageBuildContext;
+import org.jbpm.process.builder.ActionBuilder;
+import org.jbpm.process.builder.ReturnValueEvaluatorBuilder;
+import org.jbpm.process.builder.dialect.ProcessDialectRegistry;
+import org.jbpm.process.builder.dialect.java.JavaActionBuilder;
+import org.jbpm.process.builder.dialect.java.JavaProcessDialect;
+import org.jbpm.process.builder.dialect.java.JavaReturnValueEvaluatorBuilder;
+import org.jbpm.process.core.ContextResolver;
+import org.jbpm.process.instance.impl.ReturnValueConstraintEvaluator;
+import org.jbpm.workflow.core.DroolsAction;
+import org.junit.Test;
+import org.kie.api.KieBase;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CompilationTest extends JbpmBpmn2TestCase {
+
+    private static final Logger logger = LoggerFactory.getLogger(XMLBPMNProcessDumperTest.class);
+
+    public CompilationTest() {
+        super(false);
+    }
+
+    @Test
+    public void testReturnValueDescrCreation() throws Exception {
+        TestJavaProcessDialect javaProcessDialect = new TestJavaProcessDialect();
+        ProcessDialectRegistry.setDialect("java", javaProcessDialect);
+
+        String filename = "BPMN2-GatewaySplit-SequenceConditions.bpmn2";
+        KieBase kbase = createKnowledgeBase(filename);
+
+        assertFalse( "No " + ActionDescr.class.getSimpleName() + " instances caught for testing!",
+                javaProcessDialect.getActionDescrs().isEmpty() );
+        for( BaseDescr descr : javaProcessDialect.getActionDescrs() ) {
+           assertNotNull( descr.getClass().getSimpleName() +" has a null resource field", descr.getResource() );
+        }
+
+        assertFalse( "No " + ReturnValueDescr.class.getSimpleName() + " instances caught for testing!",
+                javaProcessDialect.getReturnValueDescrs().isEmpty() );
+        for( BaseDescr descr : javaProcessDialect.getReturnValueDescrs() ) {
+           assertNotNull( descr.getClass().getSimpleName() +" has a null resource field", descr.getResource() );
+        }
+    }
+
+    private static class TestJavaProcessDialect extends JavaProcessDialect {
+
+        private ActionBuilder actionBuilder = new TestJavaActionBuilder();
+        private ReturnValueEvaluatorBuilder returnValueEvaluatorBuilder = new TestJavaReturnValueEvaluatorBuilder();
+
+        @Override
+        public ActionBuilder getActionBuilder() {
+            return actionBuilder;
+        }
+
+        @Override
+        public ReturnValueEvaluatorBuilder getReturnValueEvaluatorBuilder() {
+            return returnValueEvaluatorBuilder;
+        }
+
+        public List<ActionDescr> getActionDescrs() {
+            return ((TestJavaActionBuilder) actionBuilder).actionDescrs;
+        }
+
+        public List<ReturnValueDescr> getReturnValueDescrs() {
+            return ((TestJavaReturnValueEvaluatorBuilder) returnValueEvaluatorBuilder).returnValueDescrs;
+        }
+    }
+
+    private static class TestJavaActionBuilder extends JavaActionBuilder {
+
+        List<ActionDescr> actionDescrs = new ArrayList<ActionDescr>();
+
+        @Override
+        protected void buildAction( PackageBuildContext context, DroolsAction action, ActionDescr actionDescr,
+                ContextResolver contextResolver, String className, AnalysisResult analysis ) {
+            actionDescrs.add(actionDescr);
+            super.buildAction(context, action, actionDescr, contextResolver, className, analysis);
+        }
+    }
+
+    private static class TestJavaReturnValueEvaluatorBuilder extends JavaReturnValueEvaluatorBuilder {
+
+        List<ReturnValueDescr> returnValueDescrs = new ArrayList<ReturnValueDescr>();
+
+        @Override
+        protected void buildReturnValueEvaluator( PackageBuildContext context, ReturnValueConstraintEvaluator constraintNode,
+                ReturnValueDescr descr, ContextResolver contextResolver, String className, AnalysisResult analysis ) {
+            returnValueDescrs.add(descr);
+            super.buildReturnValueEvaluator(context, constraintNode, descr, contextResolver, className, analysis);
+        }
+
+    }
+
+}

--- a/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2005 Red Hat, Inc. and/or its affiliates.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -87,7 +87,7 @@ import org.slf4j.LoggerFactory;
 public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessBuilder {
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessBuilderImpl.class);
-    
+
     private KnowledgeBuilderImpl knowledgeBuilder;
     private final List<BaseKnowledgeBuilderResultImpl> errors = new ArrayList<BaseKnowledgeBuilderResultImpl>();
 
@@ -95,7 +95,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
         this.knowledgeBuilder = packageBuilder;
         configurePackageBuilder(packageBuilder);
     }
-    
+
     public void configurePackageBuilder(KnowledgeBuilder packageBuilder) {
         KnowledgeBuilderConfigurationImpl conf = ((KnowledgeBuilderImpl) packageBuilder).getBuilderConfiguration();
         if (conf.getSemanticModules().getSemanticModule(ProcessSemanticModule.URI) == null) {
@@ -129,7 +129,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
             }
         }
         if ( !hasErrors ) {
-        	
+
             // generate and add rule for process
             String rules = "package " + process.getPackageName() + "\n";
             // NPE for validator
@@ -145,13 +145,13 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 // should never occur
                 logger.error("DroolsParserException during addPackageFromDRL", e);
             }
-            
+
             PackageRegistry pkgRegistry = this.knowledgeBuilder.getPackageRegistry(process.getPackageName());
 			if (pkgRegistry != null) {
 				InternalKnowledgePackage p = pkgRegistry.getPackage();
-            
+
 				if (p != null) {
-				    if( validator != null ) { 
+				    if( validator != null ) {
 				        // NPE for validator
 				        if (validator.compilationSupported()) {
 				            ProcessDescr processDescr = new ProcessDescr();
@@ -192,7 +192,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
 				        p.addProcess( process );
 				        // NPE for validator
 				        if (validator.compilationSupported()) {
-				            pkgRegistry.compileAll();                
+				            pkgRegistry.compileAll();
 				            pkgRegistry.getDialectRuntimeRegistry().onBeforeExecute();
 				        }
 				    }
@@ -213,18 +213,20 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
     			ExceptionScope exceptionScope = (ExceptionScope) context;
     			for (ExceptionHandler exceptionHandler: exceptionScope.getExceptionHandlers().values()) {
     				if (exceptionHandler instanceof ActionExceptionHandler) {
-    					DroolsConsequenceAction action = (DroolsConsequenceAction) 
+    					DroolsConsequenceAction action = (DroolsConsequenceAction)
     						((ActionExceptionHandler) exceptionHandler).getAction();
     					ActionDescr actionDescr = new ActionDescr();
-    			        actionDescr.setText( action.getConsequence() );   
-    			        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );            
+    			        actionDescr.setText( action.getConsequence() );
+    			        actionDescr.setResource(buildContext.getProcessDescr().getResource());
+
+    			        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );
     			        dialect.getActionBuilder().build( buildContext, action, actionDescr, (ProcessImpl) buildContext.getProcess() );
     				}
     			}
     		}
     	}
     }
-    
+
     public void buildNodes(WorkflowProcess process, ProcessBuildContext context) {
         processNodes(process.getNodes(), process, context.getProcessDescr(), context);
         if ( !context.getErrors().isEmpty() ) {
@@ -232,9 +234,9 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
         }
         ProcessDialectRegistry.getDialect(JavaDialect.ID).addProcess( context );
     }
-    
+
     private void processNodes(
-            Node[] nodes, Process process, ProcessDescr processDescr, 
+            Node[] nodes, Process process, ProcessDescr processDescr,
             ProcessBuildContext context) {
         for ( Node node : nodes ) {
             ProcessNodeBuilder builder = ProcessNodeBuilderRegistry.INSTANCE.getNodeBuilder( node );
@@ -255,7 +257,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 buildContexts( (ContextContainer) node,
                                context );
             }
-            
+
             if ("true".equals(System.getProperty("jbpm.enable.multi.con"))) {
             	builder = ProcessNodeBuilderRegistry.INSTANCE.getNodeBuilder( NodeImpl.class );
             	if (builder != null) {
@@ -286,7 +288,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 // stop null pointers
                 for (Process process : processes) {
                     buildProcess(process, resource);
-                    
+
                     xmlReader.getProcessBuildData().onBuildComplete(process);
                 }
             } else {
@@ -304,12 +306,12 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
 
         return processes;
     }
-                                   
-  
+
+
     /*************************************************************************
      * Converts a drools version 4 .rf or .rfm ruleflow to a version 5 .rf.
      * Version 5 .rf ruleflows are allowed, but are not migrated.
-     * @param reader containing any drools 4 .rf or .rfm ruleflow, or a 
+     * @param reader containing any drools 4 .rf or .rfm ruleflow, or a
      * version 5 .rf
      * @return reader containing the input reader in the latest (5) .rf format
      * @throws Exception
@@ -317,7 +319,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
     private Reader portToCurrentVersion(final Reader reader) throws Exception {
         //Migrate v4 ruleflows to v5
         String xml = RuleFlowMigrator.convertReaderToString( reader );
-        
+
         if ( RuleFlowMigrator.needToMigrateRFM(xml) ) {
             // Not a current version RFM convert it.
             xml = RuleFlowMigrator.portRFMToCurrentVersion(xml);
@@ -326,11 +328,11 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
             // Not a current version RF convert it.
             xml = RuleFlowMigrator.portRFMToCurrentVersion(xml);}
         //
-        // Note that we have also return any input v5 ruleflow as 
-        // a StringReader since the act of checking it using 
+        // Note that we have also return any input v5 ruleflow as
+        // a StringReader since the act of checking it using
         // convertReaderToString will have read the reader making it
         // appear empty if read later. As reset is not guaranteed on
-        // all Reader implementation, it is safest to convert the v5 
+        // all Reader implementation, it is safest to convert the v5
         // ruleflow string representation to a StringReader as well.
         //
         return new StringReader( xml );
@@ -367,7 +369,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
         }
         return builder.toString();
     }
- 
+
     private void generateRules(Node[] nodes, Process process, StringBuffer builder) {
         for ( int i = 0; i < nodes.length; i++ ) {
             if ( nodes[i] instanceof Split ) {
@@ -396,7 +398,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 if ( triggers != null ) {
                     for ( Trigger trigger : triggers ) {
                         if ( trigger instanceof ConstraintTrigger ) {
-                            builder.append( createStartConstraintRule( process, startNode.getNodeContainer(), 
+                            builder.append( createStartConstraintRule( process, startNode.getNodeContainer(),
                                                                        (ConstraintTrigger) trigger ) );
                         }
                     }
@@ -413,45 +415,45 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
     private String createSplitRule(Process process,
                                    Connection connection,
                                    String constraint) {
-        return 
+        return
         	"rule \"RuleFlow-Split-" + process.getId() + "-" +
-        		((org.jbpm.workflow.core.Node) connection.getFrom()).getUniqueId() + "-" + 
+        		((org.jbpm.workflow.core.Node) connection.getFrom()).getUniqueId() + "-" +
         		((org.jbpm.workflow.core.Node) connection.getTo()).getUniqueId() + "-" +
         		connection.getToType() + "\"  @Propagation(EAGER) \n" +
-        	"      ruleflow-group \"DROOLS_SYSTEM\" \n" + 
-        	"    when \n" + 
-        	"      " + constraint + "\n" + 
+        	"      ruleflow-group \"DROOLS_SYSTEM\" \n" +
+        	"    when \n" +
+        	"      " + constraint + "\n" +
         	"    then \n" +
             "end \n\n";
     }
 
     private String createMilestoneRule(Process process,
                                        MilestoneNode milestone) {
-        return 
+        return
         	"rule \"RuleFlow-Milestone-" + process.getId() + "-" + milestone.getUniqueId() + "\" @Propagation(EAGER) \n" +
-        	"      ruleflow-group \"DROOLS_SYSTEM\" \n" + 
-        	"    when \n" + 
-        	"      " + milestone.getConstraint() + "\n" + 
-        	"    then \n" + 
+        	"      ruleflow-group \"DROOLS_SYSTEM\" \n" +
+        	"    when \n" +
+        	"      " + milestone.getConstraint() + "\n" +
+        	"    then \n" +
         	"end \n\n";
     }
-    
+
     private String createStateRule(Process process, StateNode state, ConnectionRef key, Constraint constraint) {
     	if (constraint.getConstraint() == null
     			|| constraint.getConstraint().trim().length() == 0) {
     		return "";
     	} else {
-	        return 
-	        	"rule \"RuleFlowStateNode-" + process.getId() + "-" + state.getUniqueId() + "-" + 
+	        return
+	        	"rule \"RuleFlowStateNode-" + process.getId() + "-" + state.getUniqueId() + "-" +
 	        		key.getNodeId() + "-" + key.getToType() + "\" @Propagation(EAGER) \n" +
-	    		"      ruleflow-group \"DROOLS_SYSTEM\" \n" + 
-	    		"    when \n" + 
-	    		"      " + state.getConstraints().get(key).getConstraint() + "\n" + 
-	    		"    then \n" + 
+	    		"      ruleflow-group \"DROOLS_SYSTEM\" \n" +
+	    		"    when \n" +
+	    		"      " + state.getConstraints().get(key).getConstraint() + "\n" +
+	    		"    then \n" +
 	    		"end \n\n";
     	}
 	}
-    
+
     private String createEventStateRule(Process process, EventNode event) {
         String condition = (String) event.getMetaData("Condition");
         String attachedTo = (String) event.getMetaData("AttachedTo");
@@ -459,17 +461,17 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 || condition.trim().length() == 0) {
             return "";
         } else {
-            return 
-                "rule \"RuleFlowStateEvent-" + process.getId() + "-" + event.getUniqueId() + "-" + 
+            return
+                "rule \"RuleFlowStateEvent-" + process.getId() + "-" + event.getUniqueId() + "-" +
                     attachedTo + "\" @Propagation(EAGER) \n" +
-                "      ruleflow-group \"DROOLS_SYSTEM\" \n" + 
-                "    when \n" + 
-                "      " + condition + "\n" + 
+                "      ruleflow-group \"DROOLS_SYSTEM\" \n" +
+                "    when \n" +
+                "      " + condition + "\n" +
                 "    then \n" +
                 "end \n\n";
         }
     }
-    
+
     private String createEventSubprocessStateRule(Process process, CompositeNode compositeNode,
             ConstraintTrigger trigger) {
         String condition = trigger.getConstraint();
@@ -477,16 +479,16 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
                 || condition.trim().length() == 0) {
             return "";
         } else {
-            return 
+            return
                 "rule \"RuleFlowStateEventSubProcess-" + process.getId() + "-" + compositeNode.getUniqueId() + "\" @Propagation(EAGER) \n" +
-                "      ruleflow-group \"DROOLS_SYSTEM\" \n" + 
-                "    when \n" + 
-                "      " + condition + "\n" + 
+                "      ruleflow-group \"DROOLS_SYSTEM\" \n" +
+                "    when \n" +
+                "      " + condition + "\n" +
                 "    then \n" +
                 "end \n\n";
         }
     }
-    
+
     private String createStateRules(Process process, StateNode state) {
         String result = "";
         for (Map.Entry<ConnectionRef, Constraint> entry: state.getConstraints().entrySet()) {
@@ -500,12 +502,12 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
         if (nodeContainer instanceof EventSubProcessNode) {
             return createEventSubprocessStateRule(process, (EventSubProcessNode) nodeContainer, trigger);
         }
-        
-        String result = 
+
+        String result =
         	"rule \"RuleFlow-Start-" + process.getId() + "\" @Propagation(EAGER) \n" +
-        	(trigger.getHeader() == null ? "" : "        " + trigger.getHeader() + " \n") + 
-        	"    when\n" + 
-        	"        " + trigger.getConstraint() + "\n" + 
+        	(trigger.getHeader() == null ? "" : "        " + trigger.getHeader() + " \n") +
+        	"    when\n" +
+        	"        " + trigger.getConstraint() + "\n" +
         	"    then\n";
         Map<String, String> inMappings = trigger.getInMappings();
         if ( inMappings != null && !inMappings.isEmpty() ) {

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ActionNodeBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ActionNodeBuilder.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -42,17 +42,19 @@ public class ActionNodeBuilder extends ExtendedNodeBuilder {
         ActionNode actionNode = ( ActionNode ) node;
         DroolsConsequenceAction action = (DroolsConsequenceAction) actionNode.getAction();
         ActionDescr actionDescr = new ActionDescr();
-        actionDescr.setText( action.getConsequence() );   
-        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );            
+        actionDescr.setText( action.getConsequence() );
+        actionDescr.setResource(processDescr.getResource());
+
+        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );
         dialect.getActionBuilder().build( context, action, actionDescr, (NodeImpl) node );
-        
+
         Transformation transformation = (Transformation) node.getMetaData().get("Transformation");
 		if (transformation != null) {
 			WorkflowProcess wfProcess = (WorkflowProcess) process;
 			Map<String, Object> parameters = new HashMap<String, Object>();
 			parameters.put("imports", wfProcess.getImports());
 			parameters.put("classloader", context.getConfiguration().getClassLoader());
-			
+
 			DataTransformer transformer = DataTransformerRegistry.get().find(transformation.getLanguage());
 			transformation.setCompiledExpression(transformer.compile(transformation.getExpression(), parameters));
 		}

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ExtendedNodeBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/ExtendedNodeBuilder.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -46,12 +46,14 @@ public class ExtendedNodeBuilder
         	}
         }
     }
-    
+
     protected void buildAction(DroolsAction droolsAction, ProcessBuildContext context, NodeImpl node) {
     	DroolsConsequenceAction action = (DroolsConsequenceAction) droolsAction;
         ActionDescr actionDescr = new ActionDescr();
-        actionDescr.setText( action.getConsequence() );   
-        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );            
+        actionDescr.setText( action.getConsequence() );
+        actionDescr.setResource(context.getProcessDescr().getResource());
+
+        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );
     	dialect.getActionBuilder().build( context, action, actionDescr, node);
     }
 

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/MultiConditionalSequenceFlowNodeBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/MultiConditionalSequenceFlowNodeBuilder.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012 Red Hat, Inc. and/or its affiliates.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -38,21 +38,21 @@ public class MultiConditionalSequenceFlowNodeBuilder implements ProcessNodeBuild
 
 	public void build(Process process, ProcessDescr processDescr,
 			ProcessBuildContext context, Node node) {
-		
+
 		Map<ConnectionRef, Constraint> constraints = ((NodeImpl) node).getConstraints();
-		
+
 		// exclude split as it is handled with separate builder and nodes with non conditional sequence flows
 		if (node instanceof Split || constraints.size() == 0) {
 			return;
 		}
-		
+
 		// we need to clone the map, so we can update the original while iterating.
         Map<ConnectionRef, Constraint> map = new HashMap<ConnectionRef, Constraint>( constraints );
         for ( Iterator<Map.Entry<ConnectionRef, Constraint>> it = map.entrySet().iterator(); it.hasNext(); ) {
             Map.Entry<ConnectionRef, Constraint> entry = it.next();
             ConnectionRef connection = entry.getKey();
             ConstraintImpl constraint = (ConstraintImpl) entry.getValue();
-            Connection outgoingConnection = null; 
+            Connection outgoingConnection = null;
             for (Connection out: ((NodeImpl) node).getDefaultOutgoingConnections()) {
                 if (out.getToType().equals(connection.getToType())
                     && out.getTo().getId() == connection.getNodeId()) {
@@ -75,16 +75,17 @@ public class MultiConditionalSequenceFlowNodeBuilder implements ProcessNodeBuild
                 returnValueConstraint.setName( constraint.getName() );
                 returnValueConstraint.setPriority( constraint.getPriority() );
                 returnValueConstraint.setDefault( constraint.isDefault() );
-                ((NodeImpl) node).setConstraint( outgoingConnection, returnValueConstraint );            
-                
+                ((NodeImpl) node).setConstraint( outgoingConnection, returnValueConstraint );
+
                 ReturnValueDescr returnValueDescr = new ReturnValueDescr();
                 returnValueDescr.setText( constraint.getConstraint() );
-                
-                ProcessDialect dialect = ProcessDialectRegistry.getDialect( constraint.getDialect() );            
+                returnValueDescr.setResource(processDescr.getResource());
+
+                ProcessDialect dialect = ProcessDialectRegistry.getDialect( constraint.getDialect() );
             	dialect.getReturnValueEvaluatorBuilder().build( context, returnValueConstraint, returnValueDescr, (NodeImpl) node );
             }
         }
-		
+
 	}
 
 }

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/SplitNodeBuilder.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -41,7 +41,7 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
                       ProcessBuildContext context,
                       Node node) {
         Split splitNode = ( Split ) node;
-        
+
         if ( splitNode.getType() != Split.TYPE_XOR && splitNode.getType() != Split.TYPE_OR ) {
             // we only process or/xor
             return;
@@ -52,7 +52,7 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
             Map.Entry<ConnectionRef, Constraint> entry = it.next();
             ConnectionRef connection = entry.getKey();
             ConstraintImpl constraint = (ConstraintImpl) entry.getValue();
-            Connection outgoingConnection = null; 
+            Connection outgoingConnection = null;
             for (Connection out: splitNode.getDefaultOutgoingConnections()) {
                 if (out.getToType().equals(connection.getToType())
                     && out.getTo().getId() == connection.getNodeId()) {
@@ -81,12 +81,13 @@ public class SplitNodeBuilder implements ProcessNodeBuilder {
                 returnValueConstraint.setDefault( constraint.isDefault() );
                 returnValueConstraint.setType(constraint.getType());
                 returnValueConstraint.setConstraint(constraint.getConstraint());
-                splitNode.setConstraint( outgoingConnection, returnValueConstraint );            
-                
+                splitNode.setConstraint( outgoingConnection, returnValueConstraint );
+
                 ReturnValueDescr returnValueDescr = new ReturnValueDescr();
                 returnValueDescr.setText( constraint.getConstraint() );
-                
-                ProcessDialect dialect = ProcessDialectRegistry.getDialect( constraint.getDialect() );            
+                returnValueDescr.setResource(processDescr.getResource());
+
+                ProcessDialect dialect = ProcessDialectRegistry.getDialect( constraint.getDialect() );
             	dialect.getReturnValueEvaluatorBuilder().build( context, returnValueConstraint, returnValueDescr, (NodeImpl) node );
             }
         }

--- a/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/StoreNodeBuilder.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/process/builder/StoreNodeBuilder.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -36,9 +36,10 @@ public class StoreNodeBuilder
         ActionNode actionNode = ( ActionNode ) node;
         DroolsConsequenceAction action = (DroolsConsequenceAction) actionNode.getAction();
         ActionDescr actionDescr = new ActionDescr();
-        actionDescr.setText( action.getConsequence() );   
-        
-        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );            
+        actionDescr.setText( action.getConsequence() );
+        actionDescr.setResource(processDescr.getResource());
+
+        ProcessDialect dialect = ProcessDialectRegistry.getDialect( action.getDialect() );
         dialect.getActionBuilder().build( context, action, actionDescr, (NodeImpl) node );
     }
 


### PR DESCRIPTION
In short, what's important is that `BaseDescr` instances that jbpm-flow-builder generates do _not_ have `null` `.resource` fields. 

This is in order to map the type references collected from a generated, compiled (java) file to the original actual resource/asset (bpmn2/DRL/etc.).  