### PR TITLE
Fix regex in test to allow more types of versions strings

### DIFF
--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorMergerTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorMergerTest.java
@@ -528,7 +528,7 @@ public class DeploymentDescriptorMergerTest {
 		assertEquals("new org.jbpm.process.instance.impl.demo.CustomSystemOutWorkItemHandler()", model.getIdentifier());
 	}
 
-	private static final String jarLocRegexStr = "([\\d\\.]{3})\\.\\d(-SNAPSHOT)?";
+	private static final String jarLocRegexStr = "([\\d\\.]{3})\\S*";
 	private static final Pattern jarLocRegex = Pattern.compile(jarLocRegexStr);
 
 	/**


### PR DESCRIPTION
Same fix already applied to jbpm-console-ng, https://github.com/droolsjbpm/jbpm-console-ng/commit/49074353d96bad8cef4798c0f3902c8f36fb5379