### PR TITLE
JBPM-4910 - Deployed process ignores Runtime Strategy set in deployment descriptor, in managed repository project

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorImpl.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorImpl.java
@@ -42,7 +42,12 @@ import org.kie.internal.runtime.conf.NamedObjectModel;
 import org.kie.internal.runtime.conf.ObjectModel;
 import org.kie.internal.runtime.conf.PersistenceMode;
 import org.kie.internal.runtime.conf.RuntimeStrategy;
-
+/*
+ * NOTE: Whenever adding new fields that represent actual item of deployment descriptor always update:
+ * - isEmpty method
+ * - clearClone method
+ * - Builder
+ */
 @XmlRootElement(name="deployment-descriptor")
 @XmlAccessorType(XmlAccessType.NONE)
 public class DeploymentDescriptorImpl implements DeploymentDescriptor, Serializable {
@@ -376,6 +381,58 @@ public class DeploymentDescriptorImpl implements DeploymentDescriptor, Serializa
 	     removeTransient(clone.workItemHandlers);
 
 	     return clone;
+    }
+    
+    public boolean isEmpty() {
+        boolean empty = true;
+        
+        if (persistenceUnit != null) {
+            return false;
+        }
+        if (auditPersistenceUnit != null) {
+            return false;
+        }
+        if (auditMode != AuditMode.JPA) {
+            return false;
+        }
+        if (persistenceMode != PersistenceMode.JPA) {
+            return false;
+        }
+        if (runtimeStrategy != RuntimeStrategy.SINGLETON) {
+            return false;
+        }
+        if ( marshallingStrategies != null && !marshallingStrategies.isEmpty()) {
+            return false;
+        }
+        if (eventListeners != null && !eventListeners.isEmpty()) {
+            return false;
+        }
+        if (taskEventListeners != null && !taskEventListeners.isEmpty()) {
+            return false;
+        }
+        if (globals != null && !globals.isEmpty()) {
+            return false;
+        }
+        if (workItemHandlers != null && !workItemHandlers.isEmpty()) {
+            return false;
+        }
+        if (environmentEntries != null && !environmentEntries.isEmpty()) {
+            return false;
+        }
+        if (configuration != null && !configuration.isEmpty()) {
+            return false;
+        }
+        if (requiredRoles != null && !requiredRoles.isEmpty()) {
+            return false;
+        }
+        if (classes != null && !classes.isEmpty()) {
+            return false;
+        }
+        if (!limitSerializationClasses) {
+            return false;
+        }
+
+        return empty;
     }
 
     @Override

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorImpl.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorImpl.java
@@ -103,7 +103,7 @@ public class DeploymentDescriptorImpl implements DeploymentDescriptor, Serializa
 	private List<String> classes = new ArrayList<String>();
 
 	@XmlElement(name="limit-serialization-classes")
-	private Boolean limitSerializationClasses = false;
+	private Boolean limitSerializationClasses = true;
 
 	@XmlTransient
 	private Map<String, Set<String>> mappedRoles;

--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorMerger.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorMerger.java
@@ -130,8 +130,8 @@ public class DeploymentDescriptorMerger {
 				Boolean slaveLimit =  slave.getLimitSerializationClasses();
 				Boolean masterLimit =  master.getLimitSerializationClasses();
 				if( slaveLimit != null && masterLimit != null &&
-				        (slaveLimit || masterLimit) ) {
-				    builder.setLimitSerializationClasses(true);
+				        (!slaveLimit || !masterLimit) ) {
+				    builder.setLimitSerializationClasses(false);
 				}
 
 				merged = builder.get();

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorMergerTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorMergerTest.java
@@ -302,7 +302,7 @@ public class DeploymentDescriptorMergerTest {
 		assertEquals(0, outcome.getGlobals().size());
 		assertEquals(0, outcome.getTaskEventListeners().size());
 		assertEquals(0, outcome.getWorkItemHandlers().size());
-		assertTrue(outcome.getLimitSerializationClasses());
+		assertFalse(outcome.getLimitSerializationClasses());
 	}
 
 	@Test

--- a/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorTest.java
+++ b/jbpm-runtime-manager/src/test/java/org/jbpm/runtime/manager/impl/deploy/DeploymentDescriptorTest.java
@@ -16,7 +16,9 @@
 package org.jbpm.runtime.manager.impl.deploy;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
@@ -310,5 +312,39 @@ public class DeploymentDescriptorTest {
         assertEquals(0, fromXml.getTaskEventListeners().size());
         assertEquals(0, fromXml.getWorkItemHandlers().size());
         assertEquals(1, fromXml.getRequiredRoles().size());
+    }
+	
+	@Test
+    public void testEmptyDeploymentDescriptor() {
+	    DeploymentDescriptorImpl descriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+        
+        descriptor.getBuilder()
+        .addMarshalingStrategy(new ObjectModel("org.jbpm.testCustomStrategy", 
+                new Object[]{
+                new ObjectModel("java.lang.String", new Object[]{"param1"}),
+                "param2"}))
+        .addRequiredRole("experts");
+        
+        assertFalse(descriptor.isEmpty());
+        
+        InputStream input = this.getClass().getResourceAsStream("/deployment/empty-descriptor.xml");        
+        DeploymentDescriptor fromXml = DeploymentDescriptorIO.fromXml(input);
+        
+        assertNotNull(fromXml);        
+        assertTrue(((DeploymentDescriptorImpl)fromXml).isEmpty());
+        
+        assertNull(fromXml.getPersistenceUnit());
+        assertNull(fromXml.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, fromXml.getAuditMode());
+        assertEquals(PersistenceMode.JPA, fromXml.getPersistenceMode());
+        assertEquals(RuntimeStrategy.SINGLETON, fromXml.getRuntimeStrategy());
+        assertEquals(0, fromXml.getMarshallingStrategies().size());
+        assertEquals(0, fromXml.getConfiguration().size());
+        assertEquals(0, fromXml.getEnvironmentEntries().size());
+        assertEquals(0, fromXml.getEventListeners().size());
+        assertEquals(0, fromXml.getGlobals().size());       
+        assertEquals(0, fromXml.getTaskEventListeners().size());
+        assertEquals(0, fromXml.getWorkItemHandlers().size());
+        assertEquals(0, fromXml.getRequiredRoles().size());
     }
 }

--- a/jbpm-runtime-manager/src/test/resources/deployment/empty-descriptor.xml
+++ b/jbpm-runtime-manager/src/test/resources/deployment/empty-descriptor.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<deployment-descriptor/>

--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/KModuleDeploymentService.java
@@ -50,6 +50,7 @@ import org.jbpm.kie.services.impl.bpmn2.ProcessDescriptor;
 import org.jbpm.kie.services.impl.model.ProcessAssetDesc;
 import org.jbpm.process.audit.event.AuditEventBuilder;
 import org.jbpm.runtime.manager.impl.KModuleRegisterableItemsFactory;
+import org.jbpm.runtime.manager.impl.deploy.DeploymentDescriptorImpl;
 import org.jbpm.runtime.manager.impl.deploy.DeploymentDescriptorManager;
 import org.jbpm.runtime.manager.impl.deploy.DeploymentDescriptorMerger;
 import org.jbpm.runtime.manager.impl.jpa.EntityManagerFactoryManager;
@@ -239,7 +240,7 @@ public class KModuleDeploymentService extends AbstractDeploymentService {
     protected RuntimeEnvironmentBuilder boostrapRuntimeEnvironmentBuilder(KModuleDeploymentUnit deploymentUnit,
     		DeployedUnit deployedUnit, KieContainer kieContainer, MergeMode mode) {
     	DeploymentDescriptor descriptor = deploymentUnit.getDeploymentDescriptor();
-    	if (descriptor == null) {
+    	if (descriptor == null || ((DeploymentDescriptorImpl)descriptor).isEmpty()) { // skip empty descriptors as its default can override settings
 	    	DeploymentDescriptorManager descriptorManager = new DeploymentDescriptorManager("org.jbpm.domain");
 	    	List<DeploymentDescriptor> descriptorHierarchy = descriptorManager.getDeploymentDescriptorHierarchy(kieContainer);
 

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/FilteredKModuleDeploymentServiceTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/FilteredKModuleDeploymentServiceTest.java
@@ -334,7 +334,7 @@ public class FilteredKModuleDeploymentServiceTest extends AbstractKieServicesBas
            .setGroupId(groupId)
            .setArtifactId(artifactId)
            .setVersion(version)
-           .addClass(Building.class, House.class, Person.class, OtherPerson.class, Thing.class)
+           .addClass(House.class, Person.class, Thing.class)
            .createKieJarAndDeployToMaven();
        KModuleDeploymentUnit limitDeploymentUnit = new KModuleDeploymentUnit(groupId, artifactId, version);
 

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/KModuleDeploymentServiceTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/test/KModuleDeploymentServiceTest.java
@@ -522,4 +522,81 @@ public class KModuleDeploymentServiceTest extends AbstractKieServicesBaseTest {
         manager.disposeRuntimeEngine(engine);
     }
     
+    @Test
+    public void testDeploymentAvoidEmptyDescriptorOverride() {
+            
+        assertNotNull(deploymentService);
+        
+        KieServices ks = KieServices.Factory.get();
+        ReleaseId releaseId = ks.newReleaseId(GROUP_ID, "kjar-with-dd", VERSION);
+        List<String> processes = new ArrayList<String>();
+        processes.add("repo/processes/general/customtask.bpmn");
+        processes.add("repo/processes/general/humanTask.bpmn");
+        processes.add("repo/processes/general/import.bpmn");
+        
+        DeploymentDescriptor customDescriptor = new DeploymentDescriptorImpl("org.jbpm.domain");
+        customDescriptor.getBuilder()
+        .runtimeStrategy(RuntimeStrategy.PER_REQUEST)
+        .addWorkItemHandler(new NamedObjectModel("Log", "org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler"));
+        
+        Map<String, String> resources = new HashMap<String, String>();
+        resources.put("src/main/resources/" + DeploymentDescriptor.META_INF_LOCATION, customDescriptor.toXml());
+        
+        InternalKieModule kJar1 = createKieJar(ks, releaseId, processes, resources);
+        File pom = new File("target/kmodule", "pom.xml");
+        pom.getParentFile().mkdir();
+        try {
+            FileOutputStream fs = new FileOutputStream(pom);
+            fs.write(getPom(releaseId).getBytes());
+            fs.close();
+        } catch (Exception e) {
+            
+        }
+        MavenRepository repository = getMavenRepository();
+        repository.deployArtifact(releaseId, kJar1, pom);
+        
+        KModuleDeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, "kjar-with-dd", VERSION, "KBase-test", "ksession-test2"); 
+        
+        // let's simulate change of deployment descriptor on deploy time
+        deploymentUnit.setDeploymentDescriptor(new DeploymentDescriptorImpl()); // set empty one...
+        
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        DeployedUnit deployedGeneral = deploymentService.getDeployedUnit(deploymentUnit.getIdentifier());
+        assertNotNull(deployedGeneral);
+        assertNotNull(deployedGeneral.getDeploymentUnit());
+        assertNotNull(deployedGeneral.getRuntimeManager());
+        
+        DeploymentDescriptor descriptor = ((InternalRuntimeManager)deployedGeneral.getRuntimeManager()).getDeploymentDescriptor();
+        assertNotNull(descriptor);
+        assertEquals("org.jbpm.domain", descriptor.getPersistenceUnit());
+        assertEquals("org.jbpm.domain", descriptor.getAuditPersistenceUnit());
+        assertEquals(AuditMode.JPA, descriptor.getAuditMode());
+        assertEquals(PersistenceMode.JPA, descriptor.getPersistenceMode());
+        assertEquals(RuntimeStrategy.PER_REQUEST, descriptor.getRuntimeStrategy());
+        assertEquals(0, descriptor.getMarshallingStrategies().size());
+        assertEquals(0, descriptor.getConfiguration().size());
+        assertEquals(0, descriptor.getEnvironmentEntries().size());
+        assertEquals(0, descriptor.getEventListeners().size());
+        assertEquals(0, descriptor.getGlobals().size());        
+        assertEquals(0, descriptor.getTaskEventListeners().size());
+        assertEquals(1, descriptor.getWorkItemHandlers().size());
+        assertEquals(0, descriptor.getRequiredRoles().size());
+
+        RuntimeManager manager = deploymentService.getRuntimeManager(deploymentUnit.getIdentifier());
+        assertNotNull(manager);
+        
+        RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+        assertNotNull(engine);
+        
+        Map<String, Object> params = new HashMap<String, Object>();
+        
+        ProcessInstance processInstance = engine.getKieSession().startProcess("customtask", params);
+        
+        assertEquals(ProcessInstance.STATE_COMPLETED, processInstance.getState());
+        
+        manager.disposeRuntimeEngine(engine);
+        
+    }
+    
 }


### PR DESCRIPTION
@mrietveld since this (JBPM-4910) depends on fixes from https://github.com/droolsjbpm/jbpm/pull/382 I did fix in in separate commit as part of this PR. Could you please double check it's valid?