### PR TITLE
JBPM-4913: Ability to read the underlying JNDI datasource name (6.4.x)

### DIFF
--- a/jbpm-persistence-jpa/pom.xml
+++ b/jbpm-persistence-jpa/pom.xml
@@ -105,12 +105,31 @@
       <artifactId>btm</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-flow-builder</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/settings/JpaSettings.java
+++ b/jbpm-persistence-jpa/src/main/java/org/jbpm/persistence/settings/JpaSettings.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.persistence.settings;
+
+import java.io.InputStream;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class which gives access to some JPA's settings like, for instance, the JDI datasource name.
+ * <p>(see <a href="https://issues.jboss.org/browse/JBPM-4913">JBPM-4913</a>: Ability to read the underlying JNDI datasource name)</p>
+ */
+public class JpaSettings {
+
+    private static JpaSettings INSTANCE = new JpaSettings();
+
+    public static JpaSettings get() {
+        return INSTANCE;
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(JpaSettings.class);
+    private String dataSourceJndiName = null;
+
+    private JpaSettings() {
+    }
+
+    public String getDataSourceJndiName() {
+        if (dataSourceJndiName == null) {
+            dataSourceJndiName = findJndiDataSourceName();
+        }
+        return dataSourceJndiName;
+    }
+
+    public void setDataSourceJndiName(String dataSourceJndiName) {
+        this.dataSourceJndiName = dataSourceJndiName;
+    }
+
+    private String findJndiDataSourceName() {
+        String defaultName = System.getProperty("org.kie.ds.jndi", "java:jboss/datasources/ExampleDS");
+        try {
+            String jndiName = getJndiNameFromPersistenceXml();
+            if (jndiName != null) {
+                return jndiName;
+            }
+        } catch (XMLStreamException e) {
+            logger.warn("Unable to find out JNDI name fo data source " +
+                    "due to {} using default {}", e.getMessage(), defaultName, e);
+        }
+        return defaultName;
+    }
+
+    private String getJndiNameFromPersistenceXml() throws XMLStreamException {
+        XMLInputFactory factory = XMLInputFactory.newInstance();
+        InputStream is = Thread.currentThread().getContextClassLoader().getResourceAsStream("META-INF/persistence.xml");
+        XMLStreamReader reader = factory.createXMLStreamReader(is);
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT && "jta-data-source".equals(reader.getLocalName())) {
+                return reader.getElementText();
+            }
+        }
+        return null;
+
+    }
+}

--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/settings/JpaSettingsTest.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/settings/JpaSettingsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package org.jbpm.persistence.settings;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.powermock.api.mockito.PowerMockito.*;
+import static org.junit.Assert.*;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(JpaSettings.class)
+public class JpaSettingsTest {
+
+    JpaSettings jpaSettings;
+
+    @Before
+    public void setUp() {
+        System.clearProperty("org.kie.ds.jndi");
+        jpaSettings = spy(JpaSettings.get());
+    }
+
+    @Test
+    public void testReadFromPersistenceXml() {
+        String jndiName = jpaSettings.getDataSourceJndiName();
+        assertEquals(jndiName, "jdbc/testDS1");
+    }
+
+    @Test
+    public void testSetCustomJndiName() {
+        jpaSettings.setDataSourceJndiName("jdbc/myDS");
+        String jndiName = jpaSettings.getDataSourceJndiName();
+        assertEquals(jndiName, "jdbc/myDS");
+    }
+
+    @Test
+    public void testDefaultJndiName() throws Exception {
+        // Ensure no persistence-xml is found
+        when(jpaSettings,
+                PowerMockito.method(JpaSettings.class, "getJndiNameFromPersistenceXml"))
+                .withNoArguments().thenReturn(null);
+
+        String jndiName = jpaSettings.getDataSourceJndiName();
+        assertEquals(jndiName, "java:jboss/datasources/ExampleDS");
+    }
+
+    @Test
+    public void testDefaultSystemProperty() throws Exception {
+        // Ensure no persistence-xml is found
+        when(jpaSettings,
+                PowerMockito.method(JpaSettings.class, "getJndiNameFromPersistenceXml"))
+                .withNoArguments().thenReturn(null);
+
+        System.setProperty("org.kie.ds.jndi", "jdbc/MyDS");
+        String jndiName = jpaSettings.getDataSourceJndiName();
+        assertEquals(jndiName, "jdbc/MyDS");
+    }
+}


### PR DESCRIPTION
This feature is required by the jBPM console in order to retrieve from the jBPM engine what is the data source JNDI name used by the datasets that feed the UI consoles.