### PR TITLE
JBPM-4303 - using a singleton EventListener instead of empty implementations

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/DummyEventListener.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/DummyEventListener.java
@@ -1,0 +1,18 @@
+package org.jbpm.workflow.instance.impl;
+
+import org.kie.api.runtime.process.EventListener;
+
+public class DummyEventListener implements EventListener {
+
+    public final static DummyEventListener EMPTY_EVENT_LISTENER = new DummyEventListener();
+
+    private DummyEventListener() {
+    }
+
+    @Override
+    public void signalEvent( String type, Object event ) { }
+
+    @Override
+    public String[] getEventTypes() { return null; }
+
+}

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/CompositeNodeInstance.java
@@ -16,7 +16,8 @@
 
 package org.jbpm.workflow.instance.node;
 
-import java.io.Serializable;
+import static org.jbpm.workflow.instance.impl.DummyEventListener.EMPTY_EVENT_LISTENER;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -43,7 +44,6 @@ import org.jbpm.workflow.instance.impl.WorkflowProcessInstanceImpl;
 import org.kie.api.definition.process.Connection;
 import org.kie.api.definition.process.Node;
 import org.kie.api.definition.process.NodeContainer;
-import org.kie.api.runtime.process.EventListener;
 
 /**
  * Runtime counterpart of a composite node.
@@ -90,12 +90,12 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
 			if (node instanceof EventNode) {
 				if ("external".equals(((EventNode) node).getScope())) {
 					getProcessInstance().addEventListener(
-						((EventNode) node).getType(), new DoNothingEventListener(), true);
+						((EventNode) node).getType(), EMPTY_EVENT_LISTENER,  true);
 				}
 			} else if (node instanceof EventSubProcessNode) {
                 List<String> events = ((EventSubProcessNode) node).getEvents();
                 for (String type : events) {
-                    getProcessInstance().addEventListener(type, new DoNothingEventListener(), true);
+                    getProcessInstance().addEventListener(type, EMPTY_EVENT_LISTENER, true);
                 }
             }
     	}
@@ -271,6 +271,7 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
         return nodeInstance;
     }
 
+    @Override
 	public void signalEvent(String type, Object event) {
 		List<NodeInstance> currentView = new ArrayList<NodeInstance>(this.nodeInstances);
 		super.signalEvent(type, event);
@@ -396,15 +397,6 @@ public class CompositeNodeInstance extends StateBasedNodeInstance implements Nod
     		throw new IllegalArgumentException(
     			"Completing a node instance that has no outgoing connection not supported.");
 	    }
-	}
-
-	private static final class DoNothingEventListener implements EventListener, Serializable {
-		private static final long serialVersionUID = 5L;
-		public String[] getEventTypes() {
-			return null;
-		}
-		public void signalEvent(String type, Object event) {
-		}
 	}
 
     public void setState(final int state) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/DynamicNodeInstance.java
@@ -29,15 +29,15 @@ import org.kie.api.runtime.process.NodeInstance;
 public class DynamicNodeInstance extends CompositeContextNodeInstance {
 
 	private static final long serialVersionUID = 510l;
-	
+
 	private String getRuleFlowGroupName() {
 		return getNodeName();
 	}
-	
+
 	protected DynamicNode getDynamicNode() {
 		return (DynamicNode) getNode();
 	}
-	
+
     public void internalTrigger(NodeInstance from, String type) {
     	triggerEvent(ExtendedNodeImpl.EVENT_NODE_ENTER);
     	// if node instance was cancelled, abort
@@ -55,10 +55,10 @@ public class DynamicNodeInstance extends CompositeContextNodeInstance {
 
 	public void nodeInstanceCompleted(org.jbpm.workflow.instance.NodeInstance nodeInstance, String outType) {
 	    Node nodeInstanceNode = nodeInstance.getNode();
-	    if( nodeInstanceNode != null ) { 
+	    if( nodeInstanceNode != null ) {
 	        Object compensationBoolObj =  nodeInstanceNode.getMetaData().get("isForCompensation");
 	        boolean isForCompensation = compensationBoolObj == null ? false : ((Boolean) compensationBoolObj);
-	        if( isForCompensation ) { 
+	        if( isForCompensation ) {
 	            return;
 	        }
 	    }
@@ -70,21 +70,22 @@ public class DynamicNodeInstance extends CompositeContextNodeInstance {
     	} else if (completionCondition != null) {
     		Object value = MVELSafeHelper.getEvaluator().eval(completionCondition, new NodeInstanceResolverFactory(this));
     		if ( !(value instanceof Boolean) ) {
-                throw new RuntimeException( "Completion condition expression must return boolean values: " + value 
+                throw new RuntimeException( "Completion condition expression must return boolean values: " + value
                 		+ " for expression " + completionCondition);
             }
             if (((Boolean) value).booleanValue()) {
-            	triggerCompleted(NodeImpl.CONNECTION_DEFAULT_TYPE);	
+            	triggerCompleted(NodeImpl.CONNECTION_DEFAULT_TYPE);
             }
     	}
 	}
-	
+
     public void triggerCompleted(String outType) {
     	((InternalAgenda) getProcessInstance().getKnowledgeRuntime().getAgenda())
     		.deactivateRuleFlowGroup(getRuleFlowGroupName());
     	super.triggerCompleted(outType);
     }
 
+    @Override
 	public void signalEvent(String type, Object event) {
 		super.signalEvent(type, event);
 		for (Node node: getCompositeNode().getNodes()) {
@@ -95,5 +96,5 @@ public class DynamicNodeInstance extends CompositeContextNodeInstance {
     		}
 		}
 	}
-	
+
 }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/StateBasedNodeInstance.java
@@ -56,10 +56,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl implements EventBasedNodeInstanceInterface, EventListener {
-	
+
 	private static final long serialVersionUID = 510l;
     protected static final Pattern PARAMETER_MATCHER = Pattern.compile("#\\{([\\S&&[^\\}]]+)\\}", Pattern.DOTALL);
-    
+
     private static final Logger logger = LoggerFactory.getLogger(StateBasedNodeInstance.class);
 
 	private List<Long> timerInstances;
@@ -67,7 +67,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 	public StateBasedNode getEventBasedNode() {
         return (StateBasedNode) getNode();
     }
-    
+
 	public void internalTrigger(NodeInstance from, String type) {
 		super.internalTrigger(from, type);
 		// if node instance was cancelled, abort
@@ -79,19 +79,19 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 		if (timers != null) {
 			addTimerListener();
 			timerInstances = new ArrayList<Long>(timers.size());
-			TimerManager timerManager = ((InternalProcessRuntime) 
+			TimerManager timerManager = ((InternalProcessRuntime)
 				getProcessInstance().getKnowledgeRuntime().getProcessRuntime()).getTimerManager();
 			for (Timer timer: timers.keySet()) {
-				TimerInstance timerInstance = createTimerInstance(timer); 
+				TimerInstance timerInstance = createTimerInstance(timer);
 				timerManager.registerTimer(timerInstance, (ProcessInstance) getProcessInstance());
 				timerInstances.add(timerInstance.getId());
 			}
 		}
-       
+
 		if (getEventBasedNode().getBoundaryEvents() != null) {
-		    
+
 		    for (String name : getEventBasedNode().getBoundaryEvents()) {
-                
+
                 boolean isActive = ((InternalAgenda) getProcessInstance().getKnowledgeRuntime().getAgenda())
                     .isRuleActiveInRuleFlowGroup("DROOLS_SYSTEM", name, getProcessInstance().getId());
                 if (isActive) {
@@ -103,7 +103,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 		}
 		((WorkflowProcessInstanceImpl) getProcessInstance()).addActivatingNodeId((String) getNode().getMetaData().get("UniqueId"));
 	}
-	
+
     protected TimerInstance createTimerInstance(Timer timer) {
     	TimerInstance timerInstance = new TimerInstance();
     	KnowledgeRuntime kruntime = getProcessInstance().getKnowledgeRuntime();
@@ -112,11 +112,11 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
         	String delay = null;
         	switch (timer.getTimeType()) {
             case Timer.TIME_CYCLE:
-            	
+
             	if (CronExpression.isValidExpression(timer.getDelay())) {
             		timerInstance.setCronExpression(timer.getDelay());
             	} else {
-            	
+
 	            	String tempDelay = resolveVariable(timer.getDelay());
 	            	String tempPeriod = resolveVariable(timer.getPeriod());
 	            	if (DateTimeUtils.isRepeatable(tempDelay)) {
@@ -124,7 +124,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 	            		String tempRepeatLimit = values[0];
 	            		tempDelay = values[1];
 	            		tempPeriod = values[2];
-	            		
+
 	            		if (!tempRepeatLimit.isEmpty()) {
 	            			try {
 	            				int repeatLimit = Integer.parseInt(tempRepeatLimit);
@@ -136,10 +136,10 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 	            			}
 	            		}
 	            	}
-	            	
-	            	
+
+
 	            	timerInstance.setDelay(businessCalendar.calculateBusinessTimeAsDuration(tempDelay));
-	            	
+
 	            	if (tempPeriod == null) {
 	                    timerInstance.setPeriod(0);
 	                } else {
@@ -149,7 +149,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
                 break;
             case Timer.TIME_DURATION:
             	delay = resolveVariable(timer.getDelay());
-            	
+
             	timerInstance.setDelay(businessCalendar.calculateBusinessTimeAsDuration(delay));
             	timerInstance.setPeriod(0);
             	break;
@@ -159,14 +159,14 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
             default:
                 break;
             }
-        	
+
     	} else {
     	    configureTimerInstance(timer, timerInstance);
     	}
     	timerInstance.setTimerId(timer.getId());
     	return timerInstance;
     }
-    
+
     protected void configureTimerInstance(Timer timer, TimerInstance timerInstance) {
         String s = null;
         long duration = -1;
@@ -183,7 +183,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
             	if (CronExpression.isValidExpression(timer.getDelay())) {
             		timerInstance.setCronExpression(timer.getDelay());
             	} else {
-            	
+
 	                // when using ISO date/time period is not set
 	                long[] repeatValues = null;
 	                try {
@@ -239,7 +239,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
         }
 
     }
-    
+
     private long resolveValue(String s) {
     	try {
     		return TimeUtils.parseTimeString(s);
@@ -248,7 +248,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
             return TimeUtils.parseTimeString(s);
     	}
     }
-    
+
     private String resolveVariable(String s) {
     	if (s == null) {
     		return null;
@@ -263,7 +263,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
                 	resolveContextInstance(VariableScope.VARIABLE_SCOPE, paramName);
                 if (variableScopeInstance != null) {
                     Object variableValue = variableScopeInstance.getVariable(paramName);
-                	String variableValueString = variableValue == null ? "" : variableValue.toString(); 
+                	String variableValueString = variableValue == null ? "" : variableValue.toString();
 	                replacements.put(paramName, variableValueString);
                 } else {
                 	try {
@@ -281,10 +281,11 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
         for (Map.Entry<String, String> replacement: replacements.entrySet()) {
         	s = s.replace("#{" + replacement.getKey() + "}", replacement.getValue());
         }
-        
+
         return s;
     }
 
+    @Override
     public void signalEvent(String type, Object event) {
     	if ("timerTriggered".equals(type)) {
     		TimerInstance timerInstance = (TimerInstance) event;
@@ -300,7 +301,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
             }
         }
     }
-    
+
     private void triggerTimer(TimerInstance timerInstance) {
     	for (Map.Entry<Timer, DroolsAction> entry: getEventBasedNode().getTimers().entrySet()) {
     		if (entry.getKey().getId() == timerInstance.getTimerId()) {
@@ -309,26 +310,27 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
     		}
     	}
     }
-    
+
+    @Override
     public String[] getEventTypes() {
     	return new String[] { "timerTriggered", getActivationType()};
     }
-    
-    public void triggerCompleted() {        
+
+    public void triggerCompleted() {
         triggerCompleted(org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE, true);
     }
-    
+
     public void addEventListeners() {
     	if (timerInstances != null && timerInstances.size() > 0) {
     		addTimerListener();
     	}
     }
-    
+
     protected void addTimerListener() {
     	((WorkflowProcessInstance) getProcessInstance()).addEventListener("timerTriggered", this, false);
     	((WorkflowProcessInstance) getProcessInstance()).addEventListener("timer", this, true);
     }
-    
+
     public void removeEventListeners() {
     	((WorkflowProcessInstance) getProcessInstance()).removeEventListener("timerTriggered", this, false);
     	((WorkflowProcessInstance) getProcessInstance()).removeEventListener("timer", this, true);
@@ -340,11 +342,11 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 		removeActivationListener();
 		super.triggerCompleted(type, remove);
 	}
-	
+
 	public List<Long> getTimerInstances() {
 		return timerInstances;
 	}
-	
+
 	public void internalSetTimerInstances(List<Long> timerInstances) {
 		this.timerInstances = timerInstances;
 	}
@@ -355,7 +357,7 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
         removeActivationListener();
         super.cancel();
     }
-    
+
 	private void cancelTimers() {
 		// deactivate still active timers
 		if (timerInstances != null) {
@@ -366,19 +368,19 @@ public abstract class StateBasedNodeInstance extends ExtendedNodeInstanceImpl im
 			}
 		}
 	}
-	
+
 	protected String getActivationType() {
 	    return "RuleFlowStateEvent-" + this.getProcessInstance().getProcessId();
 	}
-	
+
     private void addActivationListener() {
         getProcessInstance().addEventListener(getActivationType(), this, true);
     }
-    
+
     private void removeActivationListener() {
         getProcessInstance().removeEventListener(getActivationType(), this, true);
     }
-    
+
     protected boolean checkProcessInstance(Activation activation) {
         final Map<?, ?> declarations = activation.getSubRule().getOuterDeclarations();
         for ( Iterator<?> it = declarations.values().iterator(); it.hasNext(); ) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/WorkItemNodeInstance.java
@@ -63,28 +63,28 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Runtime counterpart of a work item node.
- * 
+ *
  * @author <a href="mailto:kris_verlaenen@hotmail.com">Kris Verlaenen</a>
  */
 public class WorkItemNodeInstance extends StateBasedNodeInstance implements EventListener, ContextInstanceContainer {
-    
+
     private static final long serialVersionUID = 510l;
     private static final Logger logger = LoggerFactory.getLogger(WorkItemNodeInstance.class);
-    
+
     private static boolean variableStrictEnabled = Boolean.parseBoolean(System.getProperty("org.jbpm.variable.strict", "false"));
     private static List<String> defaultOutputVariables = Arrays.asList(new String[]{"ActorId"});
-    
+
     // NOTE: ContetxInstances are not persisted as current functionality (exception scope) does not require it
     private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
     private Map<String, List<ContextInstance>> subContextInstances = new HashMap<String, List<ContextInstance>>();
-    
+
     private long workItemId = -1;
     private transient WorkItem workItem;
-    
+
     protected WorkItemNode getWorkItemNode() {
         return (WorkItemNode) getNode();
     }
-    
+
     public WorkItem getWorkItem() {
         if (workItem == null && workItemId >= 0) {
             workItem = ((WorkItemManager) ((ProcessInstance) getProcessInstance())
@@ -92,19 +92,19 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         }
         return workItem;
     }
-    
+
     public long getWorkItemId() {
         return workItemId;
     }
-    
+
     public void internalSetWorkItemId(long workItemId) {
         this.workItemId = workItemId;
     }
-    
+
     public void internalSetWorkItem(WorkItem workItem) {
         this.workItem = workItem;
     }
-    
+
     public boolean isInversionOfControl() {
         // TODO WorkItemNodeInstance.isInversionOfControl
         return false;
@@ -157,14 +157,14 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
             triggerCompleted();
         }
         this.workItemId = workItem.getId();
-    }    
+    }
 
     protected WorkItem createWorkItem(WorkItemNode workItemNode) {
         Work work = workItemNode.getWork();
         workItem = new WorkItemImpl();
         ((WorkItem) workItem).setName(work.getName());
         ((WorkItem) workItem).setProcessInstanceId(getProcessInstance().getId());
-        ((WorkItem) workItem).setParameters(new HashMap<String, Object>(work.getParameters()));        
+        ((WorkItem) workItem).setParameters(new HashMap<String, Object>(work.getParameters()));
         for (Iterator<DataAssociation> iterator = workItemNode.getInAssociations().iterator(); iterator.hasNext(); ) {
             DataAssociation association = iterator.next();
             if (association.getTransformation() != null) {
@@ -200,7 +200,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                 }
             }
         }
-        
+
         for (Map.Entry<String, Object> entry: workItem.getParameters().entrySet()) {
             if (entry.getValue() instanceof String) {
                 String s = (String) entry.getValue();
@@ -213,7 +213,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                             resolveContextInstance(VariableScope.VARIABLE_SCOPE, paramName);
                         if (variableScopeInstance != null) {
                             Object variableValue = variableScopeInstance.getVariable(paramName);
-                            String variableValueString = variableValue == null ? "" : variableValue.toString(); 
+                            String variableValueString = variableValue == null ? "" : variableValue.toString();
                             replacements.put(paramName, variableValueString);
                         } else {
                             try {
@@ -242,7 +242,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
 		try {
 		    ProcessContext context = new ProcessContext(getProcessInstance().getKnowledgeRuntime());
 		    context.setNodeInstance(this);
-	        action.execute(getWorkItem(), context);		    
+	        action.execute(getWorkItem(), context);
 		} catch (Exception e) {
 		    throw new RuntimeException("unable to execute Assignment", e);
 		}
@@ -250,8 +250,8 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
 
     public void triggerCompleted(WorkItem workItem) {
         this.workItem = workItem;
-        WorkItemNode workItemNode = getWorkItemNode();       
-        
+        WorkItemNode workItemNode = getWorkItemNode();
+
         if (workItemNode != null && workItem.getState() == WorkItem.COMPLETED) {
             validateWorkItemResultVariable(getProcessInstance().getProcessName(), workItemNode.getOutAssociations(), workItem);
             for (Iterator<DataAssociation> iterator = getWorkItemNode().getOutAssociations().iterator(); iterator.hasNext(); ) {
@@ -264,9 +264,9 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                 		VariableScopeInstance variableScopeInstance = (VariableScopeInstance)
                         resolveContextInstance(VariableScope.VARIABLE_SCOPE, association.getTarget());
                         if (variableScopeInstance != null && parameterValue != null) {
-                              
+
                     	 	variableScopeInstance.getVariableScope().validateVariable(getProcessInstance().getProcessName(), association.getTarget(), parameterValue);
-                             
+
                             variableScopeInstance.setVariable(association.getTarget(), parameterValue);
                         } else {
                             logger.warn("Could not find variable scope for variable {}", association.getTarget());
@@ -280,7 +280,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                 } else if (association.getAssignments() == null || association.getAssignments().isEmpty()) {
                     VariableScopeInstance variableScopeInstance = (VariableScopeInstance)
                     resolveContextInstance(VariableScope.VARIABLE_SCOPE, association.getTarget());
-                    if (variableScopeInstance != null) {                    	
+                    if (variableScopeInstance != null) {
                         Object value = workItem.getResult(association.getSources().get(0));
                         if (value == null) {
                             try {
@@ -292,7 +292,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                         Variable varDef = variableScopeInstance.getVariableScope().findVariable(association.getTarget());
                         DataType dataType = varDef.getType();
                         // exclude java.lang.Object as it is considered unknown type
-                        if (!dataType.getStringType().endsWith("java.lang.Object") && 
+                        if (!dataType.getStringType().endsWith("java.lang.Object") &&
                                 !dataType.getStringType().endsWith("Object") && value instanceof String) {
                             value = dataType.readValue((String) value);
                         } else {
@@ -313,7 +313,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                }                
+                }
             }
         }
         if (isInversionOfControl()) {
@@ -323,11 +323,11 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
             triggerCompleted();
         }
     }
-  
+
     public void cancel() {
         WorkItem workItem = getWorkItem();
         if (workItem != null &&
-                workItem.getState() != WorkItem.COMPLETED && 
+                workItem.getState() != WorkItem.COMPLETED &&
                 workItem.getState() != WorkItem.ABORTED) {
             try {
                 ((WorkItemManager) ((ProcessInstance) getProcessInstance())
@@ -339,23 +339,24 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
         }
         super.cancel();
     }
-    
+
     public void addEventListeners() {
         super.addEventListeners();
         addWorkItemListener();
     }
-    
+
     private void addWorkItemListener() {
         getProcessInstance().addEventListener("workItemCompleted", this, false);
         getProcessInstance().addEventListener("workItemAborted", this, false);
     }
-    
+
     public void removeEventListeners() {
         super.removeEventListeners();
         getProcessInstance().removeEventListener("workItemCompleted", this, false);
         getProcessInstance().removeEventListener("workItemAborted", this, false);
     }
-    
+
+    @Override
     public void signalEvent(String type, Object event) {
         if ("workItemCompleted".equals(type)) {
             workItemCompleted((WorkItem) event);
@@ -369,7 +370,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
     public String[] getEventTypes() {
         return new String[] { "workItemCompleted" };
     }
-    
+
     public void workItemAborted(WorkItem workItem) {
         if ( workItemId == workItem.getId()
                 || ( workItemId == -1 && getWorkItem().getId() == workItem.getId()) ) {
@@ -385,7 +386,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
             triggerCompleted(workItem);
         }
     }
-    
+
     public String getNodeName() {
         Node node = getNode();
         if (node == null) {
@@ -452,7 +453,7 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
     public ContextContainer getContextContainer() {
         return getWorkItemNode();
     }
-    
+
     protected Map<String, Object> getSourceParameters(DataAssociation association) {
     	Map<String, Object> parameters = new HashMap<String, Object>();
     	for (String sourceParam : association.getSources()) {
@@ -472,17 +473,17 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
 	        	parameters.put(association.getTarget(), parameterValue);
 	        }
     	}
-    	
+
     	return parameters;
     }
-    
-    
+
+
     public void validateWorkItemResultVariable(String processName, List<DataAssociation> outputs, WorkItem workItem) {
-        // in case work item results are skip validation as there is no notion of mandatory data outputs 
+        // in case work item results are skip validation as there is no notion of mandatory data outputs
         if (!variableStrictEnabled || workItem.getResults().isEmpty()) {
             return;
         }
-        
+
         List<String> outputNames = new ArrayList<String>();
         for (DataAssociation association : outputs) {
             if (association.getSources() != null) {
@@ -494,13 +495,13 @@ public class WorkItemNodeInstance extends StateBasedNodeInstance implements Even
                 }
             }
         }
-        
+
         for (String outputName : workItem.getResults().keySet()) {
             if (!outputNames.contains(outputName) && !defaultOutputVariables.contains(outputName)) {
-                throw new IllegalArgumentException("Data output '" + outputName +"' is not defined in process '" 
+                throw new IllegalArgumentException("Data output '" + outputName +"' is not defined in process '"
                                                     + processName + "' for task '" + workItem.getParameter("NodeName") +"'");
             }
         }
     }
-    
+
 }


### PR DESCRIPTION
@mswiderski Could you look at this? 

I talked with @krisv about this last night: it's a minor change that, even in the current implementations, is a little more readable (and faster, I believe, not that that matters really). 

It also helps me with the stackless work, which is my main reason for adding it. 

Thanks!

The changes can be seen [here](https://github.com/droolsjbpm/jbpm/pull/388/files?w=1). In short: 

- Remove empty implementations
- Add a singleton/constant "empty event listener" impl that can be used instead

Apologies for the space changes.. :/ 