### PR TITLE
Fix random user generation in case-mgmt test coverage

### DIFF
--- a/jbpm-test-coverage/src/main/java/org/jbpm/test/casemgmt/WorkCaseService.java
+++ b/jbpm-test-coverage/src/main/java/org/jbpm/test/casemgmt/WorkCaseService.java
@@ -128,7 +128,7 @@ public class WorkCaseService {
         Random rand = new Random();
         int n = 0;
         if (users.length > 1) {
-            n = rand.nextInt(users.length - 1);
+            n = rand.nextInt(users.length);
         }
         return users[n];
     }


### PR DESCRIPTION
Hello,

when looking through the case-mgmt test coverage I have found a small issue. Since nextInt(n) picks number from 0 (inclusive) to n (exclusive), -1 was not supposed to be there (the very last user would not be picked).

Marian
