### PR TITLE
JBPM-5116 Persistence tests doesn't use transactions for handling LOBs in Postgresql Plus

### DIFF
--- a/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
+++ b/jbpm-persistence-jpa/src/test/java/org/jbpm/persistence/util/PersistenceUtil.java
@@ -338,7 +338,7 @@ public class PersistenceUtil {
 
         // Postgresql has a "Large Object" api which REQUIRES the use of transactions
         //  since @Lob/byte array is actually stored in multiple tables.
-        if (databaseDriverClassName.startsWith("org.postgresql")) {
+        if (databaseDriverClassName.startsWith("org.postgresql") || databaseDriverClassName.startsWith("com.edb")) {
             useTransactions = true;
         }
         return useTransactions;


### PR DESCRIPTION
- Added com.edb driver handling to PersistenceUtil.useTransactions() method.

Master PR: https://github.com/droolsjbpm/jbpm/pull/467

This is needed for testing next planned 6.4.x builds on Postgresql Plus.