### PR TITLE
Adding a new JPA work item handler

### DIFF
--- a/jbpm-workitems/pom.xml
+++ b/jbpm-workitems/pom.xml
@@ -242,14 +242,19 @@
 	<dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-persistence-jpa</artifactId>
+      <scope>test</scope>
     </dependency>
+	
 	<dependency>
       <groupId>org.drools</groupId>
       <artifactId>drools-persistence-jpa</artifactId>
+      <scope>test</scope>
     </dependency> 
-    	<dependency>
+    
+    <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-runtime-manager</artifactId>
+      <scope>test</scope>
     </dependency>       
   </dependencies>
 </project>

--- a/jbpm-workitems/pom.xml
+++ b/jbpm-workitems/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm</artifactId>
-    <version>7.0.0-SNAPSHOT</version>
+    <version>6.4.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitems</artifactId>
@@ -214,6 +214,25 @@
       <artifactId>jboss-jms-api_1.1_spec</artifactId>
       <scope>provided</scope>
     </dependency>
+    
+    <!-- JPA -->
+    <dependency>
+      <groupId>org.hibernate.javax.persistence</groupId>
+      <artifactId>hibernate-jpa-2.0-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+	<dependency>
+	    <groupId>org.hibernate</groupId>
+	    <artifactId>hibernate-entitymanager</artifactId>
+		<scope>provided</scope>
+	</dependency>
+    
+    <!-- JTA -->
+	<dependency>
+	    <groupId>org.jboss.spec.javax.transaction</groupId>
+	    <artifactId>jboss-transaction-api_1.1_spec</artifactId>
+	    <scope>provided</scope>
+	</dependency>
+    
   </dependencies>
-
 </project>

--- a/jbpm-workitems/pom.xml
+++ b/jbpm-workitems/pom.xml
@@ -238,6 +238,18 @@
 	    <artifactId>jboss-transaction-api_1.1_spec</artifactId>
 	    <scope>provided</scope>
 	</dependency>
-    
+	
+	<dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-persistence-jpa</artifactId>
+    </dependency>
+	<dependency>
+      <groupId>org.drools</groupId>
+      <artifactId>drools-persistence-jpa</artifactId>
+    </dependency> 
+    	<dependency>
+      <groupId>org.jbpm</groupId>
+      <artifactId>jbpm-runtime-manager</artifactId>
+    </dependency>       
   </dependencies>
 </project>

--- a/jbpm-workitems/pom.xml
+++ b/jbpm-workitems/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.jbpm</groupId>
     <artifactId>jbpm</artifactId>
-    <version>6.4.1-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>jbpm-workitems</artifactId>

--- a/jbpm-workitems/src/main/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandler.java
+++ b/jbpm-workitems/src/main/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandler.java
@@ -17,6 +17,24 @@ import org.kie.internal.runtime.Cacheable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * 
+ * A WorkItemHandler to perform JPA operations. <br />
+ * An <b>Action</b> must be provided as an input parameter. The supported value for the Action parameters:
+ * <ul>
+ * <li>Create: Persist the object and return the attached entity. TO persist an object you must provide the object using the WIH parameter <b>Entity</b></li>
+ * <li>Update: Update an attached entity and returns the updated entity. You must provide the attached entity using the <b>Entity</b> WIH parameter.</li>
+ * <li>Delete: Delete an attached entity. You must provide the attached entity using the <b>Entity</b> WIH parameter.</li>
+ * <li>Get: Get an entity by ID. You must provide the return type using the <b>Type</b> parameter with the FQN of the target class and the ID using the <b>Id</b> parameter.</li>
+ * <li>Query: Executes a named query and return the list of results (if any). The query must be provided using the <b>Query</b> input parameter and you may provide query parameters in the form of a Map with key String and value Object using the 
+ * <b>QueryParameters</b> WIH input parameter. The result of the query is put on the output parameter <b>QueryResults</b>.
+ * </li>
+ * </ul>
+ * When registering the WIH in the deployment descriptor, you must provide the classloader where your mapped entities are and the name of the persistence unit you configured in <em>persistence.xml</em>.
+ * 
+ * @author wsiqueir
+ *
+ */
 public class JPAWorkItemHandler extends AbstractLogOrThrowWorkItemHandler implements Cacheable {
 	
 	private static final Logger logger = LoggerFactory.getLogger(JPAWorkItemHandler.class);

--- a/jbpm-workitems/src/main/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandler.java
+++ b/jbpm-workitems/src/main/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandler.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.jbpm.process.workitem.jpa;
 
 import java.util.Collections;
@@ -44,7 +59,7 @@ public class JPAWorkItemHandler extends AbstractLogOrThrowWorkItemHandler implem
 	public static final String P_ID = "Id";
 	public static final String P_ENTITY = "Entity";
 	public static final String P_ACTION = "Action";
-	public static final String p_QUERY = "Query";
+	public static final String P_QUERY = "Query";
 	public static final String P_QUERY_PARAMS = "QueryParameters";
 	public static final String P_QUERY_RESULTS = "QueryResults";
 	
@@ -78,7 +93,7 @@ public class JPAWorkItemHandler extends AbstractLogOrThrowWorkItemHandler implem
 		Object entity = wi.getParameter(P_ENTITY);
 		Object id = wi.getParameter(P_ID);
 		Object type = wi.getParameter(P_TYPE);
-		Object queryName = wi.getParameter(p_QUERY);
+		Object queryName = wi.getParameter(P_QUERY);
 		Object queryParams = wi.getParameter(P_QUERY_PARAMS);
 		Map<String, Object> params = new HashMap<String, Object>();
 		List<Object> queryResults = Collections.emptyList();
@@ -113,7 +128,7 @@ public class JPAWorkItemHandler extends AbstractLogOrThrowWorkItemHandler implem
 			break;
 		case QUERY_ACTION:
 			if(queryName == null) {
-				throw new IllegalArgumentException("You must provide a '" + p_QUERY + "' parameter to run named queries.");
+				throw new IllegalArgumentException("You must provide a '" + P_QUERY + "' parameter to run named queries.");
 			}
 			queryResults = doQuery(String.valueOf(queryName), queryParams);
 			break;

--- a/jbpm-workitems/src/main/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandler.java
+++ b/jbpm-workitems/src/main/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandler.java
@@ -1,0 +1,156 @@
+package org.jbpm.process.workitem.jpa;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+import javax.persistence.Query;
+
+import org.jbpm.process.workitem.AbstractLogOrThrowWorkItemHandler;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemManager;
+import org.kie.internal.runtime.Cacheable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JPAWorkItemHandler extends AbstractLogOrThrowWorkItemHandler implements Cacheable {
+	
+	private static final Logger logger = LoggerFactory.getLogger(JPAWorkItemHandler.class);
+
+	public static final String P_RESULT = "Result";
+	public static final String P_TYPE = "Type";
+	public static final String P_ID = "Id";
+	public static final String P_ENTITY = "Entity";
+	public static final String P_ACTION = "Action";
+	public static final String p_QUERY = "Query";
+	public static final String P_QUERY_PARAMS = "QueryParameters";
+	public static final String P_QUERY_RESULTS = "QueryResults";
+	
+	public static final String CREATE_ACTION = "CREATE";
+	public static final String UPDATE_ACTION = "UPDATE";
+	public static final String GET_ACTION = "GET";
+	public static final String DELETE_ACTION = "DELETE";
+	public static final String QUERY_ACTION = "QUERY";
+	
+	private EntityManagerFactory emf;
+	private EntityManager em;
+	
+	private ClassLoader classloader;
+	
+	public  JPAWorkItemHandler(String persistenceUnit, ClassLoader cl) {
+		setLogThrownException(true);
+        ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        try {
+            Thread.currentThread().setContextClassLoader(cl);
+            this.emf = Persistence.createEntityManagerFactory(persistenceUnit);
+
+        } finally {
+            Thread.currentThread().setContextClassLoader(tccl);
+        }
+        em = emf.createEntityManager();
+        this.classloader = cl;
+    }
+		
+	public void executeWorkItem(WorkItem wi, WorkItemManager wim) {
+		Object actionParam = wi.getParameter(P_ACTION);
+		Object entity = wi.getParameter(P_ENTITY);
+		Object id = wi.getParameter(P_ID);
+		Object type = wi.getParameter(P_TYPE);
+		Object queryName = wi.getParameter(p_QUERY);
+		Object queryParams = wi.getParameter(P_QUERY_PARAMS);
+		Map<String, Object> params = new HashMap<String, Object>();
+		List<Object> queryResults = Collections.emptyList();
+		String action;
+		if(actionParam == null) {
+			throw new IllegalArgumentException("An action is required. Use 'delete', 'create', 'update', query or 'get'");
+		}
+		// Only QUERY does no require an entity parameter
+		if(entity == null && P_ACTION.equals(QUERY_ACTION)) {
+			throw new IllegalArgumentException("An entity is required. Use the 'entity' parameter");
+		}
+		// join the process transaction
+		em.joinTransaction();
+		action = String.valueOf(actionParam).trim().toUpperCase();
+		logger.debug("Action {} on {}", action, entity);
+		switch (action) {
+		case DELETE_ACTION:
+			doDelete(entity);
+			break;
+		case GET_ACTION:
+			if(id == null || type == null) {
+				throw new IllegalArgumentException("Id or type can't be null when getting an entity");
+			}
+			// only works with long for now
+			entity = doGet(type.toString(), Long.parseLong(id.toString()));
+			break;
+		case UPDATE_ACTION:
+			doUpdate(entity);
+			break;
+		case CREATE_ACTION:
+			doCreate(entity);
+			break;
+		case QUERY_ACTION:
+			if(queryName == null) {
+				throw new IllegalArgumentException("You must provide a '" + p_QUERY + "' parameter to run named queries.");
+			}
+			queryResults = doQuery(String.valueOf(queryName), queryParams);
+			break;
+		default:
+			throw new IllegalArgumentException("Action " + action + " not recognized. Use 'delete', 'create', 'update', query, or 'get'");
+		}
+		params.put(P_RESULT, entity);
+		params.put(P_QUERY_RESULTS, queryResults);
+		wim.completeWorkItem(wi.getId(), params);
+	}
+
+	@SuppressWarnings("unchecked")
+	private List<Object> doQuery(String queryName, Object queryParams) {
+		logger.debug("About to run query {}", queryName);
+		Map<String, Object> params;
+		Query namedQuery = em.createQuery(queryName);
+		if(queryParams == null) {
+			logger.debug("No parameters were provided");
+		} else {
+			params = ((Map<String, Object>) queryParams);
+			logger.debug("Parameters {}", params);
+			params.forEach(namedQuery::setParameter);
+		}
+		return namedQuery.getResultList();
+	}
+
+	private void doCreate(Object entity) {
+		em.persist(entity);
+	}
+
+	private Object doUpdate(Object entity) {
+		return em.merge(entity);
+	}
+
+	private Object doGet(String clazz, Object id) {
+		Class<?> type;
+		try {
+			type = Class.forName(clazz, false, classloader);
+		} catch (ClassNotFoundException e) {
+			throw new IllegalArgumentException("Can't load type " + clazz);
+		}
+		return em.find(type, id);
+	}
+
+	private void doDelete(Object entity) {
+		em.remove(entity);
+	}
+
+	public void close() {
+		em.clear();
+		em.close();
+		emf.close();
+	}
+	
+	public void abortWorkItem(WorkItem wi, WorkItemManager wim) {
+		wim.abortWorkItem(wi.getId());
+	}
+}

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.jbpm.process.workitem.jpa;
 
 import static org.junit.Assert.assertEquals;
@@ -126,7 +141,7 @@ public class JPAWorkItemHandlerTest {
 				JPAWorkItemHandler.QUERY_ACTION);
 		Map<String, Object> params = new HashMap<>();
 		params.put("desc", DESC);
-		workItem.setParameter(JPAWorkItemHandler.p_QUERY,
+		workItem.setParameter(JPAWorkItemHandler.P_QUERY,
 				"SELECT p FROM Product p where p.description = :desc");
 		workItem.setParameter(JPAWorkItemHandler.P_QUERY_PARAMS, params);
 		UserTransaction ut = getUserTransaction();
@@ -170,7 +185,7 @@ public class JPAWorkItemHandlerTest {
 		WorkItemImpl workItem = new WorkItemImpl();
 		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
 				JPAWorkItemHandler.QUERY_ACTION);
-		workItem.setParameter(JPAWorkItemHandler.p_QUERY,
+		workItem.setParameter(JPAWorkItemHandler.P_QUERY,
 				"SELECT p FROM Product p");
 		UserTransaction ut = getUserTransaction();
 		ut.begin();
@@ -242,13 +257,12 @@ public class JPAWorkItemHandlerTest {
 	    params.put("action", action);
 	    params.put("obj", prod);
 	    kSession.startProcess("org.jbpm.JPA_WIH", params);
-	    kSession.dispose();
 	    manager.disposeRuntimeEngine(engine);
 	    manager.close();
 	}
 
 	private UserTransaction getUserTransaction() throws NamingException {
-		return (UserTransaction) new InitialContext().lookup("java:comp/UserTransaction");
+		return (UserTransaction) InitialContext.doLookup("java:comp/UserTransaction");
 	}
 
 	private class TestWorkItemManager implements WorkItemManager {

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
@@ -36,7 +36,6 @@ import org.kie.api.runtime.process.WorkItemManager;
 import org.kie.internal.io.ResourceFactory;
 import org.kie.internal.runtime.manager.context.EmptyContext;
 
-import bitronix.tm.TransactionManagerServices;
 import bitronix.tm.resource.jdbc.PoolingDataSource;
 
 public class JPAWorkItemHandlerTest {
@@ -94,9 +93,10 @@ public class JPAWorkItemHandlerTest {
 		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
 				JPAWorkItemHandler.UPDATE_ACTION);
 		workItem.setParameter(JPAWorkItemHandler.P_ENTITY, product);
-		TransactionManagerServices.getTransactionManager().begin();
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
-		TransactionManagerServices.getTransactionManager().commit();
+		ut.commit();
 		product = getProduct(id);
 		assertEquals(newDescription, product.getDescription());
 	}
@@ -129,9 +129,10 @@ public class JPAWorkItemHandlerTest {
 		workItem.setParameter(JPAWorkItemHandler.p_QUERY,
 				"SELECT p FROM Product p where p.description = :desc");
 		workItem.setParameter(JPAWorkItemHandler.P_QUERY_PARAMS, params);
-		TransactionManagerServices.getTransactionManager().begin();
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
-		TransactionManagerServices.getTransactionManager().commit();
+		ut.commit();
 		@SuppressWarnings("unchecked")
 		List<Product> products = (List<Product>) workItem
 				.getResult(JPAWorkItemHandler.P_QUERY_RESULTS);
@@ -171,9 +172,10 @@ public class JPAWorkItemHandlerTest {
 				JPAWorkItemHandler.QUERY_ACTION);
 		workItem.setParameter(JPAWorkItemHandler.p_QUERY,
 				"SELECT p FROM Product p");
-		TransactionManagerServices.getTransactionManager().begin();
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
-		TransactionManagerServices.getTransactionManager().commit();
+		ut.commit();
 		@SuppressWarnings("unchecked")
 		List<Product> products = (List<Product>) workItem
 		.getResult(JPAWorkItemHandler.P_QUERY_RESULTS);
@@ -187,9 +189,10 @@ public class JPAWorkItemHandlerTest {
 		workItem.setParameter(JPAWorkItemHandler.P_TYPE,
 				"org.jbpm.process.workitem.jpa.Product");
 		workItem.setParameter(JPAWorkItemHandler.P_ID, id);
-		TransactionManagerServices.getTransactionManager().begin();
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
-		TransactionManagerServices.getTransactionManager().commit();
+		ut.commit();
 		Product product = (Product) workItem
 				.getResult(JPAWorkItemHandler.P_RESULT);
 		return product;
@@ -201,9 +204,10 @@ public class JPAWorkItemHandlerTest {
 		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
 				JPAWorkItemHandler.CREATE_ACTION);
 		workItem.setParameter(JPAWorkItemHandler.P_ENTITY, product);
-		TransactionManagerServices.getTransactionManager().begin();
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
-		TransactionManagerServices.getTransactionManager().commit();
+		ut.commit();
 		Product result = (Product) workItem
 				.getResult(JPAWorkItemHandler.P_RESULT);
 		return result;
@@ -214,9 +218,10 @@ public class JPAWorkItemHandlerTest {
 		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
 				JPAWorkItemHandler.DELETE_ACTION);
 		workItem.setParameter(JPAWorkItemHandler.P_ENTITY, product);
-		TransactionManagerServices.getTransactionManager().begin();
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
-		TransactionManagerServices.getTransactionManager().commit();
+		ut.commit();
 	}
 	
 	private void startJPAWIHProcess(String action, Product prod) throws Exception {

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
@@ -10,26 +10,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 import javax.persistence.TypedQuery;
+import javax.transaction.UserTransaction;
 
 import org.drools.core.process.instance.impl.WorkItemImpl;
 import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Server;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.kie.api.KieBase;
-import org.kie.api.KieServices;
-import org.kie.api.builder.KieBuilder;
-import org.kie.api.builder.KieFileSystem;
-import org.kie.api.builder.Results;
-import org.kie.api.io.Resource;
 import org.kie.api.io.ResourceType;
-import org.kie.api.runtime.Environment;
-import org.kie.api.runtime.EnvironmentName;
-import org.kie.api.runtime.KieContainer;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.manager.RuntimeEngine;
 import org.kie.api.runtime.manager.RuntimeEnvironment;
@@ -39,10 +33,7 @@ import org.kie.api.runtime.manager.RuntimeManagerFactory;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemHandler;
 import org.kie.api.runtime.process.WorkItemManager;
-import org.kie.internal.KnowledgeBaseFactory;
 import org.kie.internal.io.ResourceFactory;
-import org.kie.internal.persistence.jpa.JPAKnowledgeService;
-import org.kie.internal.runtime.StatefulKnowledgeSession;
 import org.kie.internal.runtime.manager.context.EmptyContext;
 
 import bitronix.tm.TransactionManagerServices;
@@ -50,7 +41,6 @@ import bitronix.tm.resource.jdbc.PoolingDataSource;
 
 public class JPAWorkItemHandlerTest {
 	
-	private static final String DESCRIPTION = "Ball";
 	private static final String P_UNIT = "org.jbpm.test.jpaWIH";
 	private static EntityManagerFactory emf;
 	private static WorkItemHandler handler;
@@ -91,7 +81,6 @@ public class JPAWorkItemHandlerTest {
 		removeProduct(p1);
 		removeProduct(p2);
 	}
-
 
 	@Test
 	public void modifyActionTest() throws Exception {
@@ -158,16 +147,22 @@ public class JPAWorkItemHandlerTest {
 	
 	@Test
 	public void createOnProcessTest() throws Exception {
-		Product p = new Product(DESCRIPTION, 10f);
+		String DESC = "Table";
+		Product p = new Product(DESC, 10f);
 		startJPAWIHProcess(JPAWorkItemHandler.CREATE_ACTION, p);
+		UserTransaction ut = getUserTransaction();
+		ut.begin();
 		EntityManager em = emf.createEntityManager();
 		// WIP
 		TypedQuery<Product> products = em.createQuery("select p from Product p where p.description = :desc", Product.class);
-		products.setParameter("desc", DESCRIPTION);
-		Product result = products.getResultList().iterator().next();
-		assertEquals(DESCRIPTION, result.getDescription());
+		products.setParameter("desc", DESC);
+		List<Product> resultList = products.getResultList();
+		Product result = resultList.iterator().next();
+		assertEquals(DESC, result.getDescription());
 		em.remove(result);
+		em.flush();
 		em.close();
+		ut.commit();
 	}
 
 	private List<Product> getAllProducts() throws Exception {
@@ -224,25 +219,31 @@ public class JPAWorkItemHandlerTest {
 		TransactionManagerServices.getTransactionManager().commit();
 	}
 	
-	private void startJPAWIHProcess(String action, Product prod) {
-		
-		KieServices ks = KieServices.Factory.get();
-		KieFileSystem kfs = ks.newKieFileSystem();
-		kfs.write(ks.getResources().newClassPathResource("JPAWIH.bpmn2"));
-		// throw exception
-		ks.newKieBuilder(kfs).buildAll();
-		KieContainer kieContainer = ks.newKieContainer(ks.getRepository().getDefaultReleaseId());
-		KieBase kbase = kieContainer.getKieBase();
-		EntityManagerFactory emf = Persistence.createEntityManagerFactory( "org.jbpm.persistence.jpa" );
-		Environment env = KnowledgeBaseFactory.newEnvironment();
-		
-		env.set( EnvironmentName.ENTITY_MANAGER_FACTORY, emf );
-		StatefulKnowledgeSession kSession = JPAKnowledgeService.newStatefulKnowledgeSession( kbase, null, env );
-	    HashMap<String, Object> params = new HashMap<>();
+	private void startJPAWIHProcess(String action, Product prod) throws Exception {
+		EntityManagerFactory emf = Persistence.createEntityManagerFactory("org.jbpm.persistence.jpa");
+		RuntimeEnvironment env = 
+		     RuntimeEnvironmentBuilder.Factory.get().newDefaultBuilder()
+		     .entityManagerFactory(emf) 
+		     .addAsset(ResourceFactory.newClassPathResource("JPAWIH.bpmn2"),ResourceType.BPMN2)
+		     .get();		
+		RuntimeManager manager = RuntimeManagerFactory.Factory.get().newSingletonRuntimeManager(env);
+		RuntimeEngine engine = manager.getRuntimeEngine(EmptyContext.get());
+		KieSession kSession = engine.getKieSession();
+
+		JPAWorkItemHandler jpaWih = new JPAWorkItemHandler(P_UNIT, this.getClass().getClassLoader());
+		kSession.getWorkItemManager().registerWorkItemHandler("JPAWIH", jpaWih);
+	    
+		HashMap<String, Object> params = new HashMap<>();
 	    params.put("action", action);
 	    params.put("obj", prod);
 	    kSession.startProcess("org.jbpm.JPA_WIH", params);
-		kSession.dispose();
+	    kSession.dispose();
+	    manager.disposeRuntimeEngine(engine);
+	    manager.close();
+	}
+
+	private UserTransaction getUserTransaction() throws NamingException {
+		return (UserTransaction) new InitialContext().lookup("java:comp/UserTransaction");
 	}
 
 	private class TestWorkItemManager implements WorkItemManager {

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/JPAWorkItemHandlerTest.java
@@ -1,0 +1,250 @@
+package org.jbpm.process.workitem.jpa;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.drools.core.process.instance.impl.WorkItemImpl;
+import org.h2.tools.DeleteDbFiles;
+import org.h2.tools.Server;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.kie.api.runtime.process.WorkItem;
+import org.kie.api.runtime.process.WorkItemHandler;
+import org.kie.api.runtime.process.WorkItemManager;
+
+import bitronix.tm.TransactionManagerServices;
+import bitronix.tm.resource.jdbc.PoolingDataSource;
+
+public class JPAWorkItemHandlerTest {
+	
+	private static final String P_UNIT = "org.jbpm.test.jpaWIH";
+
+	static WorkItemHandler handler;
+
+	private static TestH2Server h2Server;
+
+	@BeforeClass
+	public static void setDS() throws InterruptedException {
+		setupPoolingDataSource();
+		ClassLoader classLoader = JPAWorkItemHandler.class.getClassLoader();
+		handler = new JPAWorkItemHandler(P_UNIT, classLoader);
+	}
+
+	@Test
+	public void createActionTest() throws Exception {
+		Product product = create(new Product("some product", 0.1f));
+		assertNotEquals(0, product.getId());
+		removeProduct(product);
+	}
+
+	@Test
+	public void getActionTest() throws Exception {
+		Product newProd = create(new Product("some product", 0.1f));
+		String id = String.valueOf(newProd.getId());
+		Product product = getProduct(id);
+		assertNotNull(product);
+		removeProduct(product);
+	}
+
+	@Test
+	public void queryActionTest() throws Exception {
+		Product p1 = create(new Product("some prod", 2f));
+		Product p2 =  create(new Product("other prod", 3f));
+		List<Product> products = getAllProducts();
+		assertEquals(2, products.size());
+		removeProduct(p1);
+		removeProduct(p2);
+	}
+
+
+	@Test
+	public void modifyActionTest() throws Exception {
+		String newDescription = "New prod description";
+		Product product = create(new Product("prod desc", 1f));
+		String id = String.valueOf(product.getId());
+		assertNotNull(product);
+		product.setDescription(newDescription);
+		
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
+				JPAWorkItemHandler.UPDATE_ACTION);
+		workItem.setParameter(JPAWorkItemHandler.P_ENTITY, product);
+		TransactionManagerServices.getTransactionManager().begin();
+		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
+		TransactionManagerServices.getTransactionManager().commit();
+		product = getProduct(id);
+		assertEquals(newDescription, product.getDescription());
+	}
+	
+	@Test
+	public void removeActionTest() throws Exception {
+		Product product = create(new Product("some des", 3f));
+		String id = String.valueOf(product.getId());
+		assertNotNull(getProduct(id));
+		removeProduct(product);
+		product = getProduct(id);
+		assertNull(product);
+	}
+	
+	@Test
+	public void queryWithParameterActionTest() throws Exception {
+		String DESC = "Cheese";
+		Product p1 = new Product("Bread", 2f);
+		Product p2 = new Product("Milk", 3f);
+		Product p3 = new Product(DESC, 5f);
+		create(p1);
+		create(p2);
+		create(p3);
+		
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
+				JPAWorkItemHandler.QUERY_ACTION);
+		Map<String, Object> params = new HashMap<>();
+		params.put("desc", DESC);
+		workItem.setParameter(JPAWorkItemHandler.p_QUERY,
+				"SELECT p FROM Product p where p.description = :desc");
+		workItem.setParameter(JPAWorkItemHandler.P_QUERY_PARAMS, params);
+		TransactionManagerServices.getTransactionManager().begin();
+		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
+		TransactionManagerServices.getTransactionManager().commit();
+		@SuppressWarnings("unchecked")
+		List<Product> products = (List<Product>) workItem
+				.getResult(JPAWorkItemHandler.P_QUERY_RESULTS);
+		assertEquals(1, products.size());
+		products = getAllProducts();
+		assertEquals(3, products.size());
+		for (Product product : products) {
+			removeProduct(product);
+		}
+		products = getAllProducts();
+		assertEquals(0, products.size());
+	}
+
+	private List<Product> getAllProducts() throws Exception {
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
+				JPAWorkItemHandler.QUERY_ACTION);
+		workItem.setParameter(JPAWorkItemHandler.p_QUERY,
+				"SELECT p FROM Product p");
+		TransactionManagerServices.getTransactionManager().begin();
+		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
+		TransactionManagerServices.getTransactionManager().commit();
+		@SuppressWarnings("unchecked")
+		List<Product> products = (List<Product>) workItem
+		.getResult(JPAWorkItemHandler.P_QUERY_RESULTS);
+		return products;
+	}
+	
+	private Product getProduct(String id) throws Exception {
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
+				JPAWorkItemHandler.GET_ACTION);
+		workItem.setParameter(JPAWorkItemHandler.P_TYPE,
+				"org.jbpm.process.workitem.jpa.Product");
+		workItem.setParameter(JPAWorkItemHandler.P_ID, id);
+		TransactionManagerServices.getTransactionManager().begin();
+		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
+		TransactionManagerServices.getTransactionManager().commit();
+		Product product = (Product) workItem
+				.getResult(JPAWorkItemHandler.P_RESULT);
+		return product;
+	}
+	
+	private Product create(Product product)
+			throws Exception {
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
+				JPAWorkItemHandler.CREATE_ACTION);
+		workItem.setParameter(JPAWorkItemHandler.P_ENTITY, product);
+		TransactionManagerServices.getTransactionManager().begin();
+		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
+		TransactionManagerServices.getTransactionManager().commit();
+		Product result = (Product) workItem
+				.getResult(JPAWorkItemHandler.P_RESULT);
+		return result;
+	}
+	
+	private void removeProduct(Product product) throws Exception {
+		WorkItemImpl workItem = new WorkItemImpl();
+		workItem.setParameter(JPAWorkItemHandler.P_ACTION,
+				JPAWorkItemHandler.DELETE_ACTION);
+		workItem.setParameter(JPAWorkItemHandler.P_ENTITY, product);
+		TransactionManagerServices.getTransactionManager().begin();
+		handler.executeWorkItem(workItem, new TestWorkItemManager(workItem));
+		TransactionManagerServices.getTransactionManager().commit();
+	}
+
+	private class TestWorkItemManager implements WorkItemManager {
+
+		private WorkItem workItem;
+
+		TestWorkItemManager(WorkItem workItem) {
+			this.workItem = workItem;
+		}
+
+		public void completeWorkItem(long id, Map<String, Object> results) {
+			((WorkItemImpl) workItem).setResults(results);
+
+		}
+
+		public void abortWorkItem(long id) {
+
+		}
+
+		public void registerWorkItemHandler(String workItemName,
+				WorkItemHandler handler) {
+		}
+
+	}
+
+	public static PoolingDataSource setupPoolingDataSource() {
+		h2Server = new TestH2Server();
+		h2Server.start();
+		PoolingDataSource pds = new PoolingDataSource();
+		pds.setMaxPoolSize(10);
+		pds.setMinPoolSize(10);
+		pds.setUniqueName("jpaWIH");
+		pds.setClassName("bitronix.tm.resource.jdbc.lrc.LrcXADataSource");
+		pds.setAllowLocalTransactions(true);
+		pds.getDriverProperties().put("user", "sa");
+		pds.getDriverProperties().put("url", "jdbc:h2:mem:jpa-wih;MVCC=true");
+		pds.getDriverProperties().put("driverClassName", "org.h2.Driver");
+		pds.init();
+		return pds;
+	}
+
+	private static class TestH2Server {
+		private Server realH2Server;
+
+		public void start() {
+			if (realH2Server == null || !realH2Server.isRunning(false)) {
+				try {
+					realH2Server = Server.createTcpServer(new String[0]);
+					realH2Server.start();
+					System.out.println("Started H2 Server...");
+				} catch (SQLException e) {
+					throw new RuntimeException("can't start h2 server db", e);
+				}
+			}
+		}
+
+		@Override
+		protected void finalize() throws Throwable {
+			if (realH2Server != null) {
+				System.out.println("Stopping H2 Server...");
+				realH2Server.stop();
+			}
+			DeleteDbFiles.execute("", "target/jpa-wih", true);
+			super.finalize();
+		}
+
+	}
+
+}

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/Product.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/Product.java
@@ -1,13 +1,17 @@
 package org.jbpm.process.workitem.jpa;
 
+import java.io.Serializable;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
 @Entity
-public class Product {
+public class Product implements Serializable {
 	
+	private static final long serialVersionUID = 1L;
+
 	@Id
 	@GeneratedValue
 	private long id;

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/Product.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/Product.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2015 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
 package org.jbpm.process.workitem.jpa;
 
 import java.io.Serializable;

--- a/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/Product.java
+++ b/jbpm-workitems/src/test/java/org/jbpm/process/workitem/jpa/Product.java
@@ -1,0 +1,61 @@
+package org.jbpm.process.workitem.jpa;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Product {
+	
+	@Id
+	@GeneratedValue
+	private long id;
+	
+	@Column
+	private String description;
+	
+	@Column
+	private float price;
+
+	public Product() {
+	}
+
+	
+	public Product(String description, float price) {
+		super();
+		this.description = description;
+		this.price = price;
+	}
+
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public float getPrice() {
+		return price;
+	}
+
+	public void setPrice(float price) {
+		this.price = price;
+	}
+	
+	@Override
+	public String toString() {
+		return "[id=" + id + ", description=" + description + ", price=" + price + "]";
+	}
+
+}

--- a/jbpm-workitems/src/test/resources/JPAWIH.bpmn2
+++ b/jbpm-workitems/src/test/resources/JPAWIH.bpmn2
@@ -3,60 +3,88 @@
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:java="http://www.java.com/javaTypes" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.1.3.Final" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
   <bpmn2:itemDefinition id="ItemDefinition_19" isCollection="false" structureRef="String"/>
   <bpmn2:itemDefinition id="ItemDefinition_187" isCollection="false" structureRef="Object"/>
+  <bpmn2:itemDefinition id="ItemDefinition_1" isCollection="false" structureRef="java.lang.Object"/>
+  <bpmn2:itemDefinition id="ItemDefinition_2" isCollection="false" structureRef="java.lang.String"/>
   <bpmn2:process id="org.jbpm.JPA_WIH" tns:packageName="org.jbpm" name="JPA WIH" isExecutable="true" processType="Private">
     <bpmn2:property id="action" itemSubjectRef="ItemDefinition_19" name="action"/>
     <bpmn2:property id="obj" itemSubjectRef="ItemDefinition_187" name="obj"/>
     <bpmn2:property id="id" itemSubjectRef="ItemDefinition_19" name="id"/>
+    <bpmn2:property id="queryParameters" itemSubjectRef="ItemDefinition_187" name="queryParameters"/>
+    <bpmn2:property id="query" itemSubjectRef="ItemDefinition_19" name="query"/>
+    <bpmn2:property id="type" itemSubjectRef="ItemDefinition_19" name="type"/>
     <bpmn2:startEvent id="StartEvent_1" name="StartProcess">
-      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+      <bpmn2:outgoing>SequenceFlow_5</bpmn2:outgoing>
     </bpmn2:startEvent>
-    <bpmn2:serviceTask id="ServiceTask_1" name="JPAWIH">
-      <bpmn2:extensionElements>
-        <tns:onEntry-script scriptFormat="http://www.java.com/java">
-          <tns:script>System.out.println(&quot;JPAWIH Process: Entering JPA WIH&quot;);</tns:script>
-        </tns:onEntry-script>
-        <tns:onExit-script scriptFormat="http://www.java.com/java">
-          <tns:script>System.out.println(&quot;JPAWIH Process: Leaving JPA WIH&quot;);</tns:script>
-        </tns:onExit-script>
-      </bpmn2:extensionElements>
-      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
-      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
-      <bpmn2:ioSpecification id="InputOutputSpecification_6">
-        <bpmn2:dataInput id="DataInput_2" itemSubjectRef="ItemDefinition_19" name="action"/>
-        <bpmn2:dataInput id="DataInput_4" itemSubjectRef="ItemDefinition_187" name="entity"/>
-        <bpmn2:inputSet id="_InputSet_3" name="Input Set 3">
-          <bpmn2:dataInputRefs>DataInput_2</bpmn2:dataInputRefs>
-          <bpmn2:dataInputRefs>DataInput_4</bpmn2:dataInputRefs>
-        </bpmn2:inputSet>
-        <bpmn2:outputSet id="OutputSet_5" name="Output Set 5"/>
-      </bpmn2:ioSpecification>
-      <bpmn2:dataInputAssociation id="DataInputAssociation_2">
-        <bpmn2:sourceRef>action</bpmn2:sourceRef>
-        <bpmn2:targetRef>DataInput_2</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-      <bpmn2:dataInputAssociation id="DataInputAssociation_4">
-        <bpmn2:sourceRef>obj</bpmn2:sourceRef>
-        <bpmn2:targetRef>DataInput_4</bpmn2:targetRef>
-      </bpmn2:dataInputAssociation>
-    </bpmn2:serviceTask>
-    <bpmn2:sequenceFlow id="SequenceFlow_1" tns:priority="1" sourceRef="StartEvent_1" targetRef="ServiceTask_1"/>
     <bpmn2:endEvent id="EndEvent_1" name="End Event 1">
       <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
     </bpmn2:endEvent>
-    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" sourceRef="ServiceTask_1" targetRef="EndEvent_1"/>
+    <bpmn2:task id="Task_4" tns:taskName="JPAWIH" tns:displayName="JPA" tns:icon="task.png" name="JPA">
+      <bpmn2:extensionElements>
+        <tns:onEntry-script scriptFormat="http://www.java.com/java">
+          <tns:script>System.out.println(&quot;>> Entering JPA WIH&quot;);</tns:script>
+        </tns:onEntry-script>
+        <tns:onExit-script scriptFormat="http://www.java.com/java">
+          <tns:script>System.out.println(&quot;>> Leaving JPA WIH&quot;);</tns:script>
+        </tns:onExit-script>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_5</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_3">
+        <bpmn2:dataInput id="DataInput_15" itemSubjectRef="ItemDefinition_187" name="Entity"/>
+        <bpmn2:dataInput id="DataInput_16" itemSubjectRef="ItemDefinition_19" name="Action"/>
+        <bpmn2:dataInput id="DataInput_17" itemSubjectRef="ItemDefinition_19" name="Type"/>
+        <bpmn2:dataInput id="DataInput_18" itemSubjectRef="ItemDefinition_19" name="Id"/>
+        <bpmn2:dataInput id="DataInput_19" itemSubjectRef="ItemDefinition_19" name="Query"/>
+        <bpmn2:dataInput id="DataInput_20" itemSubjectRef="ItemDefinition_187" name="QueryParameters"/>
+        <bpmn2:dataOutput id="DataOutput_5" itemSubjectRef="ItemDefinition_1" name="Result"/>
+        <bpmn2:dataOutput id="DataOutput_6" itemSubjectRef="ItemDefinition_1" name="QueryResults"/>
+        <bpmn2:inputSet id="_InputSet_7">
+          <bpmn2:dataInputRefs>DataInput_15</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_16</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_17</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_18</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_19</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_20</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_OutputSet_4">
+          <bpmn2:dataOutputRefs>DataOutput_5</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>DataOutput_6</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_DataInputAssociation_14">
+        <bpmn2:sourceRef>obj</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_15</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_DataInputAssociation_15">
+        <bpmn2:sourceRef>action</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_16</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_DataInputAssociation_16">
+        <bpmn2:sourceRef>type</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_17</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_DataInputAssociation_17">
+        <bpmn2:sourceRef>id</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_18</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_DataInputAssociation_18">
+        <bpmn2:sourceRef>query</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_19</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_DataInputAssociation_19">
+        <bpmn2:sourceRef>queryParameters</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_20</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:task>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" sourceRef="Task_4" targetRef="EndEvent_1"/>
+    <bpmn2:sequenceFlow id="SequenceFlow_5" tns:priority="1" sourceRef="StartEvent_1" targetRef="Task_4"/>
   </bpmn2:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="org.jbpm.JPA_WIH">
       <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
-        <dc:Bounds height="36.0" width="36.0" x="120.0" y="120.0"/>
+        <dc:Bounds height="36.0" width="36.0" x="130.0" y="120.0"/>
         <bpmndi:BPMNLabel id="BPMNLabel_1">
-          <dc:Bounds height="14.0" width="69.0" x="104.0" y="156.0"/>
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="BPMNShape_ServiceTask_1" bpmnElement="ServiceTask_1">
-        <dc:Bounds height="50.0" width="110.0" x="227.0" y="113.0"/>
-        <bpmndi:BPMNLabel id="BPMNLabel_2">
-          <dc:Bounds height="14.0" width="44.0" x="260.0" y="131.0"/>
+          <dc:Bounds height="14.0" width="69.0" x="114.0" y="156.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
@@ -65,18 +93,24 @@
           <dc:Bounds height="14.0" width="66.0" x="404.0" y="156.0"/>
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_ServiceTask_1">
-        <di:waypoint xsi:type="dc:Point" x="156.0" y="138.0"/>
-        <di:waypoint xsi:type="dc:Point" x="198.0" y="138.0"/>
-        <di:waypoint xsi:type="dc:Point" x="227.0" y="138.0"/>
-        <bpmndi:BPMNLabel id="BPMNLabel_4"/>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_ServiceTask_1" targetElement="BPMNShape_EndEvent_1">
-        <di:waypoint xsi:type="dc:Point" x="337.0" y="138.0"/>
-        <di:waypoint xsi:type="dc:Point" x="378.0" y="138.0"/>
-        <di:waypoint xsi:type="dc:Point" x="378.0" y="138.0"/>
+      <bpmndi:BPMNShape id="BPMNShape_Task_4" bpmnElement="Task_4">
+        <dc:Bounds height="50.0" width="110.0" x="240.0" y="113.0"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds height="14.0" width="21.0" x="284.0" y="131.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_Task_4" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="350.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="387.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="387.0" y="138.0"/>
         <di:waypoint xsi:type="dc:Point" x="419.0" y="138.0"/>
-        <bpmndi:BPMNLabel id="BPMNLabel_5"/>
+        <bpmndi:BPMNLabel/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_5" bpmnElement="SequenceFlow_5" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_Task_4">
+        <di:waypoint xsi:type="dc:Point" x="166.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="203.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="240.0" y="138.0"/>
+        <bpmndi:BPMNLabel/>
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/jbpm-workitems/src/test/resources/JPAWIH.bpmn2
+++ b/jbpm-workitems/src/test/resources/JPAWIH.bpmn2
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- origin at X=0.0 Y=0.0 -->
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:java="http://www.java.com/javaTypes" xmlns:tns="http://www.jboss.org/drools" xmlns="http://www.jboss.org/drools" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" id="Definition" exporter="org.eclipse.bpmn2.modeler.core" exporterVersion="1.1.3.Final" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.jboss.org/drools" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="ItemDefinition_19" isCollection="false" structureRef="String"/>
+  <bpmn2:itemDefinition id="ItemDefinition_187" isCollection="false" structureRef="Object"/>
+  <bpmn2:process id="org.jbpm.JPA_WIH" tns:packageName="org.jbpm" name="JPA WIH" isExecutable="true" processType="Private">
+    <bpmn2:property id="action" itemSubjectRef="ItemDefinition_19" name="action"/>
+    <bpmn2:property id="obj" itemSubjectRef="ItemDefinition_187" name="obj"/>
+    <bpmn2:property id="id" itemSubjectRef="ItemDefinition_19" name="id"/>
+    <bpmn2:startEvent id="StartEvent_1" name="StartProcess">
+      <bpmn2:outgoing>SequenceFlow_1</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:serviceTask id="ServiceTask_1" name="JPAWIH">
+      <bpmn2:extensionElements>
+        <tns:onEntry-script scriptFormat="http://www.java.com/java">
+          <tns:script>System.out.println(&quot;JPAWIH Process: Entering JPA WIH&quot;);</tns:script>
+        </tns:onEntry-script>
+        <tns:onExit-script scriptFormat="http://www.java.com/java">
+          <tns:script>System.out.println(&quot;JPAWIH Process: Leaving JPA WIH&quot;);</tns:script>
+        </tns:onExit-script>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>SequenceFlow_1</bpmn2:incoming>
+      <bpmn2:outgoing>SequenceFlow_2</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="InputOutputSpecification_6">
+        <bpmn2:dataInput id="DataInput_2" itemSubjectRef="ItemDefinition_19" name="action"/>
+        <bpmn2:dataInput id="DataInput_4" itemSubjectRef="ItemDefinition_187" name="entity"/>
+        <bpmn2:inputSet id="_InputSet_3" name="Input Set 3">
+          <bpmn2:dataInputRefs>DataInput_2</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>DataInput_4</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="OutputSet_5" name="Output Set 5"/>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_2">
+        <bpmn2:sourceRef>action</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_2</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="DataInputAssociation_4">
+        <bpmn2:sourceRef>obj</bpmn2:sourceRef>
+        <bpmn2:targetRef>DataInput_4</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+    </bpmn2:serviceTask>
+    <bpmn2:sequenceFlow id="SequenceFlow_1" tns:priority="1" sourceRef="StartEvent_1" targetRef="ServiceTask_1"/>
+    <bpmn2:endEvent id="EndEvent_1" name="End Event 1">
+      <bpmn2:incoming>SequenceFlow_2</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="SequenceFlow_2" tns:priority="1" sourceRef="ServiceTask_1" targetRef="EndEvent_1"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_Process_1" bpmnElement="org.jbpm.JPA_WIH">
+      <bpmndi:BPMNShape id="BPMNShape_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="120.0" y="120.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_1">
+          <dc:Bounds height="14.0" width="69.0" x="104.0" y="156.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_ServiceTask_1" bpmnElement="ServiceTask_1">
+        <dc:Bounds height="50.0" width="110.0" x="227.0" y="113.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_2">
+          <dc:Bounds height="14.0" width="44.0" x="260.0" y="131.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds height="36.0" width="36.0" x="419.0" y="120.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_3">
+          <dc:Bounds height="14.0" width="66.0" x="404.0" y="156.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_1" bpmnElement="SequenceFlow_1" sourceElement="BPMNShape_StartEvent_1" targetElement="BPMNShape_ServiceTask_1">
+        <di:waypoint xsi:type="dc:Point" x="156.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="198.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="227.0" y="138.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_4"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_SequenceFlow_2" bpmnElement="SequenceFlow_2" sourceElement="BPMNShape_ServiceTask_1" targetElement="BPMNShape_EndEvent_1">
+        <di:waypoint xsi:type="dc:Point" x="337.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="378.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="378.0" y="138.0"/>
+        <di:waypoint xsi:type="dc:Point" x="419.0" y="138.0"/>
+        <bpmndi:BPMNLabel id="BPMNLabel_5"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn2:definitions>

--- a/jbpm-workitems/src/test/resources/META-INF/persistence.xml
+++ b/jbpm-workitems/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.0"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+	xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+	<persistence-unit name="org.jbpm.test.jpaWIH"
+		transaction-type="JTA">
+		<provider>org.hibernate.ejb.HibernatePersistence</provider>
+		<jta-data-source>jpaWIH</jta-data-source>
+
+		<class>org.jbpm.process.workitem.jpa.Product</class>
+
+		<properties>
+			<property name="hibernate.max_fetch_depth" value="3" />
+			<property name="hibernate.hbm2ddl.auto" value="update" />
+			<property name="hibernate.show_sql" value="true" />
+			<property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+
+			<!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem 
+				to cause problems -->
+			<property name="hibernate.id.new_generator_mappings" value="false" />
+			<property name="hibernate.transaction.jta.platform"
+				value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform" />
+		</properties>
+	</persistence-unit>
+
+
+</persistence>    

--- a/jbpm-workitems/src/test/resources/META-INF/persistence.xml
+++ b/jbpm-workitems/src/test/resources/META-INF/persistence.xml
@@ -24,5 +24,34 @@
 		</properties>
 	</persistence-unit>
 
+	<persistence-unit name="org.jbpm.persistence.jpa"
+		transaction-type="JTA">
+		<provider>org.hibernate.ejb.HibernatePersistence</provider>
+		<non-jta-data-source>jpaWIH</non-jta-data-source>
+		<mapping-file>META-INF/JBPMorm.xml</mapping-file>
+
+		<class>org.drools.persistence.info.SessionInfo</class>
+		<class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+		<class>org.drools.persistence.info.WorkItemInfo</class>
+		<class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+		<class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+		<class>org.jbpm.runtime.manager.impl.jpa.ContextMappingInfo</class>
+
+		<class>org.jbpm.process.audit.ProcessInstanceLog</class>
+		<class>org.jbpm.process.audit.NodeInstanceLog</class>
+		<class>org.jbpm.process.audit.VariableInstanceLog</class>
+		<properties>
+			<property name="hibernate.max_fetch_depth" value="3" />
+			<property name="hibernate.hbm2ddl.auto" value="update" />
+			<property name="hibernate.show_sql" value="true" />
+			<property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect" />
+
+			<!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem 
+				to cause problems -->
+			<property name="hibernate.id.new_generator_mappings" value="false" />
+			<property name="hibernate.transaction.jta.platform"
+				value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform" />
+		</properties>
+	</persistence-unit>
 
 </persistence>    

--- a/jbpm-workitems/src/test/resources/SampleWorkDefinitions.conf
+++ b/jbpm-workitems/src/test/resources/SampleWorkDefinitions.conf
@@ -129,6 +129,24 @@ import org.drools.core.process.core.datatype.impl.type.StringDataType;
     ],
     "displayName" : "Handler",
     "customEditor" : "org.drools.eclipse.flow.common.editor.editpart.work.SampleCustomEditor"
+  ],
+  
+    [
+    "name" : "JPAWIH",
+    "parameters" : [
+        "Entity" : new ObjectDataType(),
+        "Action" : new StringDataType(),
+        "Type" : new StringDataType(),
+        "Id" : new ObjectDataType(),
+        "Query" : new StringDataType(),
+        "QueryParameters" : new ObjectDataType()
+    ],
+    "results" : [
+        "Result" : new ObjectDataType(),
+        "QueryResults" : new ObjectDataType()
+    ],
+    "displayName" : "JPA",
+    "customEditor" : "org.drools.eclipse.flow.common.editor.editpart.work.SampleCustomEditor"
   ]
   
 ]

--- a/jbpm-workitems/src/test/resources/jndi.properties
+++ b/jbpm-workitems/src/test/resources/jndi.properties
@@ -1,0 +1,1 @@
+java.naming.factory.initial=bitronix.tm.jndi.BitronixInitialContextFactory

--- a/jbpm-workitems/src/test/resources/logback-test.xml
+++ b/jbpm-workitems/src/test/resources/logback-test.xml
@@ -14,7 +14,7 @@
   <logger name="org.apache.cxf" level="error"/>
   <logger name="org.hibernate" level="warn"/>
   
-  <root level="info">
+  <root level="trace">
     <appender-ref ref="consoleAppender" />
   </root>
 


### PR DESCRIPTION
This is a Pull Request to add the JPA WorkItemHandler to the work item handlers collections. The aim of the JPA WIH is to allow users to perform JPA operations against a persistence unit created in the persistence descriptor. The supported operations are: create, update, delete, get and query. The general instructions to use it are in the JPA WIH javadoc and also in these posts:

http://fxapps.blogspot.com.br/2016/04/a-jbpm-6-jpa-work-item-handler.html
http://fxapps.blogspot.com.br/2016/05/a-crud-using-jbpm.html

If there's any problem, please let me know.