### PR TITLE
Remove no longer needed -XX:MaxPermSize configs

### DIFF
--- a/jbpm-installer/build.for.eclipse.luna.xml
+++ b/jbpm-installer/build.for.eclipse.luna.xml
@@ -485,7 +485,7 @@
   <target name="start.jboss">
     <property name="jboss.full.path.win" location="${jboss.home}/bin/standalone.bat" />
     <exec executable="${jboss.full.path.win}" spawn="yes" osfamily="windows">
-      <env key="JAVA_OPTS" value="-XX:MaxPermSize=256m -Xms256m -Xmx512m" />
+      <env key="JAVA_OPTS" value="-Xms256m -Xmx512m" />
       <arg value="-b" />
       <arg value="${jboss.bind.address}" />
       <arg value="--server-config=standalone-full.xml" />
@@ -494,7 +494,7 @@
     </exec>
     <property name="jboss.full.path.linux" location="${jboss.home}/bin/standalone.sh" />
     <exec executable="${jboss.full.path.linux}" spawn="yes" osfamily="unix">
-      <env key="JAVA_OPTS" value="-XX:MaxPermSize=256m -Xms256m -Xmx512m" />
+      <env key="JAVA_OPTS" value="-Xms256m -Xmx512m" />
       <arg value="-b" />
       <arg value="${jboss.bind.address}" />
       <arg value="--server-config=standalone-full.xml" />

--- a/jbpm-installer/build.xml
+++ b/jbpm-installer/build.xml
@@ -527,7 +527,7 @@
   <target name="start.jboss">
     <property name="jboss.full.path.win" location="${jboss.home}/bin/standalone.bat" />
     <exec executable="${jboss.full.path.win}" spawn="yes" osfamily="windows">
-      <env key="JAVA_OPTS" value="-XX:MaxPermSize=256m -Xms256m -Xmx512m" />
+      <env key="JAVA_OPTS" value="-Xms256m -Xmx512m" />
       <arg value="-b" />
       <arg value="${jboss.bind.address}" />
       <arg value="--server-config=standalone-full.xml" />
@@ -542,7 +542,7 @@
     </exec>
     <property name="jboss.full.path.linux" location="${jboss.home}/bin/standalone.sh" />
     <exec executable="${jboss.full.path.linux}" spawn="yes" osfamily="unix">
-      <env key="JAVA_OPTS" value="-XX:MaxPermSize=256m -Xms256m -Xmx512m" />
+      <env key="JAVA_OPTS" value="-Xms256m -Xmx512m" />
       <arg value="-b" />
       <arg value="${jboss.bind.address}" />
       <arg value="--server-config=standalone-full.xml" />

--- a/jbpm-services/jbpm-services-ejb/jbpm-executor-ejb/src/test/resources/arquillian.xml
+++ b/jbpm-services/jbpm-services-ejb/jbpm-executor-ejb/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
   <container qualifier="jboss" default="true">
     <configuration>
       <property name="jbossHome">${jboss.server.home}</property>
-      <property name="javaVmArguments">-Xms512m -Xmx1024m -XX:MaxPermSize=512m</property>
+      <property name="javaVmArguments">-Xms512m -Xmx1024m</property>
     </configuration>
   </container>
 </arquillian>

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/test/resources/arquillian.xml
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-impl/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
   <container qualifier="jboss" default="true">
     <configuration>
       <property name="jbossHome">${jboss.server.home}</property>
-      <property name="javaVmArguments">-Xms512m -Xmx1024m -XX:MaxPermSize=512m</property>
+      <property name="javaVmArguments">-Xms512m -Xmx1024m</property>
     </configuration>
   </container>
 </arquillian>

--- a/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/test/resources/arquillian.xml
+++ b/jbpm-services/jbpm-services-ejb/jbpm-services-ejb-timer/src/test/resources/arquillian.xml
@@ -6,7 +6,7 @@
   <container qualifier="jboss" default="true">
     <configuration>
       <property name="jbossHome">${jboss.server.home}</property>
-      <property name="javaVmArguments">-Xms512m -Xmx1024m -XX:MaxPermSize=512m</property>
+      <property name="javaVmArguments">-Xms512m -Xmx1024m</property>
     </configuration>
   </container>
 </arquillian>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,6 @@
               <exclude>**/*AbstractTest.java</exclude>
               <exclude>**/*JMS*Test.java</exclude>
             </excludes>
-            <argLine>-Xmx1024m -XX:MaxPermSize=128m</argLine>
             <additionalClasspathElements>
               <additionalClasspathElement>${maven.jdbc.driver.jar}</additionalClasspathElement>
             </additionalClasspathElements>


### PR DESCRIPTION
 * deprecated in JDK 8 (e.g. has no effect) and
   removed in JDK 9 (build fails)