### PR TITLE
JBPM-5157 - Refactoring of LDAPUserGroupCallbackImpl and LDAPUserInfoImpl

### DIFF
--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/AbstractLDAPUserGroupInfo.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/AbstractLDAPUserGroupInfo.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.jbpm.services.task.identity;
+
+import java.util.Properties;
+
+import javax.naming.Context;
+
+import org.jbpm.services.task.utils.LdapSearcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+abstract class AbstractLDAPUserGroupInfo extends AbstractUserGroupInfo {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractLDAPUserGroupInfo.class);
+
+    public static final String BIND_USER = "ldap.bind.user";
+    public static final String BIND_PWD = "ldap.bind.pwd";
+
+    protected static final String DEFAULT_ROLE_ATTR_ID = "cn";
+    protected static final String DEFAULT_USER_ATTR_ID = "uid";
+
+    private Properties config;
+
+    protected LdapSearcher ldapSearcher;
+
+    protected AbstractLDAPUserGroupInfo(String[] requiredProperties, String defaultPropertiesName) {
+        String propertiesLocation = System.getProperty(defaultPropertiesName);
+        String defaultPropertiesLocation = "classpath:/" + defaultPropertiesName + ".properties";
+        Properties config = readProperties(propertiesLocation, defaultPropertiesLocation);
+
+        initialize(requiredProperties, config);
+    }
+
+    protected AbstractLDAPUserGroupInfo(String[] requiredProperties, Properties config) {
+        initialize(requiredProperties, config);
+    }
+
+    private void initialize(String[] requiredProperties, Properties config) {
+        this.config = config;
+
+        validateProperties(requiredProperties);
+        copyConfigProperty(BIND_USER, Context.SECURITY_PRINCIPAL);
+        copyConfigProperty(BIND_PWD, Context.SECURITY_CREDENTIALS);
+
+        ldapSearcher = new LdapSearcher(this.config);
+    }
+
+    private void copyConfigProperty(String sourceKey, String targetKey) {
+        String value = config.getProperty(sourceKey);
+        if (value != null) {
+            config.setProperty(targetKey, value);
+        }
+    }
+
+    private void validateProperties(String[] requiredProperties) {
+        if (config == null) {
+            throw new IllegalArgumentException("No configuration found for " + getClass().getSimpleName()
+                    + ", aborting...");
+        }
+
+        StringBuffer missingProperties = new StringBuffer();
+        for (String requiredProperty : requiredProperties) {
+            if (!config.containsKey(requiredProperty)) {
+                if (missingProperties.length() > 0) {
+                    missingProperties.append(", ");
+                }
+                missingProperties.append(requiredProperty);
+            }
+        }
+
+        if (missingProperties.length() > 0) {
+            logger.debug("Validation failed due to missing required properties: {}", missingProperties.toString());
+
+            throw new IllegalArgumentException("Missing required properties to configure " + getClass().getSimpleName()
+                    + ": " + missingProperties.toString());
+        }
+    }
+
+    public String getConfigProperty(String key) {
+        return config.getProperty(key);
+    }
+
+    public String getConfigProperty(String key, String defaultValue) {
+        return config.getProperty(key, defaultValue);
+    }
+
+}

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/LDAPUserGroupCallbackImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/LDAPUserGroupCallbackImpl.java
@@ -17,54 +17,41 @@
 package org.jbpm.services.task.identity;
 
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-
-import javax.naming.Context;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.SearchControls;
 import javax.naming.directory.SearchResult;
-import javax.naming.ldap.InitialLdapContext;
 
 import org.kie.api.task.UserGroupCallback;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * LDAP integration for Task Service to collect user and role/group information.
- * 
+ * <p>
  * Following is a list of all supported properties:
  * <ul>
- *  <li>ldap.bind.user (optional if LDAP server accepts anonymous access)</li>
- *  <li>ldap.bind.pwd (optional if LDAP server accepts anonymous access</li>
- *  <li>ldap.user.ctx (mandatory)</li>
- *  <li>ldap.role.ctx (mandatory)</li>
- *  <li>ldap.user.roles.ctx (optional, if not given ldap.role.ctx will be used)</li>
- *  <li>ldap.user.filter (mandatory)</li>
- *  <li>ldap.role.filter (mandatory)</li>
- *  <li>ldap.user.roles.filter (mandatory)</li>
- *  <li>ldap.user.attr.id (optional, if not given 'uid' will be used)</li>
- *  <li>ldap.roles.attr.id (optional, if not given 'cn' will be used)</li>
- *  <li>ldap.user.id.dn (optional, is user id a DN, instructs the callback to query for user DN before searching for roles, default false)</li>
- *  <li>ldap.search.scope (optional, if not given 'OBJECT_SCOPE' will be used) possible values are: OBJECT_SCOPE, ONELEVEL_SCOPE, SUBTREE_SCOPE</li>
- *  <li>java.naming.factory.initial</li>
- *  <li>java.naming.security.authentication</li>
- *  <li>java.naming.security.protocol</li>
- *  <li>java.naming.provider.url</li>
- *  <li></li>
+ * <li>ldap.bind.user (optional if LDAP server accepts anonymous access)</li>
+ * <li>ldap.bind.pwd (optional if LDAP server accepts anonymous access</li>
+ * <li>ldap.user.ctx (mandatory)</li>
+ * <li>ldap.role.ctx (mandatory)</li>
+ * <li>ldap.user.roles.ctx (optional, if not given ldap.role.ctx will be used)</li>
+ * <li>ldap.user.filter (mandatory)</li>
+ * <li>ldap.role.filter (mandatory)</li>
+ * <li>ldap.user.roles.filter (mandatory)</li>
+ * <li>ldap.user.attr.id (optional, if not given 'uid' will be used)</li>
+ * <li>ldap.roles.attr.id (optional, if not given 'cn' will be used)</li>
+ * <li>ldap.user.id.dn (optional, is user id a DN, instructs the callback to query for user DN before searching for roles, default false)</li>
+ * <li>ldap.search.scope (optional, if not given 'ONELEVEL_SCOPE' will be used) possible values are: OBJECT_SCOPE, ONELEVEL_SCOPE, SUBTREE_SCOPE</li>
+ * <li>java.naming.factory.initial</li>
+ * <li>java.naming.security.authentication</li>
+ * <li>java.naming.security.protocol</li>
+ * <li>java.naming.provider.url</li>
+ * <li></li>
  * </ul>
+ * </p>
  */
-public class LDAPUserGroupCallbackImpl extends AbstractUserGroupInfo implements UserGroupCallback {
-    
-    private static final Logger logger = LoggerFactory.getLogger(LDAPUserGroupCallbackImpl.class);
-    
-    protected static final String DEFAULT_PROPERTIES_NAME = "classpath:/jbpm.usergroup.callback.properties";
-    
-    public static final String BIND_USER = "ldap.bind.user";
-    public static final String BIND_PWD = "ldap.bind.pwd";
+public class LDAPUserGroupCallbackImpl extends AbstractLDAPUserGroupInfo implements UserGroupCallback {
+
+    private static final String DEFAULT_PROPERTIES_NAME = "jbpm.usergroup.callback";
+
     public static final String USER_CTX = "ldap.user.ctx";
     public static final String ROLE_CTX = "ldap.role.ctx";
     public static final String USER_ROLES_CTX = "ldap.user.roles.ctx";
@@ -75,283 +62,71 @@ public class LDAPUserGroupCallbackImpl extends AbstractUserGroupInfo implements 
     public static final String ROLE_ATTR_ID = "ldap.roles.attr.id";
     public static final String IS_USER_ID_DN = "ldap.user.id.dn";
     public static final String SEARCH_SCOPE = "ldap.search.scope";
-    
-    protected static final String[] requiredProperties = {USER_CTX, ROLE_CTX, USER_FILTER, ROLE_FILTER, USER_ROLES_FILTER};
 
-    
-    private Properties config;
-    
-    //no no-arg constructor to prevent cdi from auto deploy
+    private static final String[] REQUIRED_PROPERTIES = {USER_CTX, ROLE_CTX, USER_FILTER, ROLE_FILTER, USER_ROLES_FILTER};
+
+    private static final String DEFAULT_USER_ID_DN = "false";
+
+    /**
+     * Constructor needs to have at least one (unused) parameter in order to prevent CDI from automatic deployment.
+     * Configuration properties are loaded from a file specified by jbpm.usergroup.callback system property or
+     * classpath:/jbpm.usergroup.callback.properties file.
+     * @param activate ignored
+     */
     public LDAPUserGroupCallbackImpl(boolean activate) {
-        String propertiesLocation = System.getProperty("jbpm.usergroup.callback.properties");
-        
-        config = readProperties(propertiesLocation, DEFAULT_PROPERTIES_NAME);       
-        validate();
+        super(REQUIRED_PROPERTIES, DEFAULT_PROPERTIES_NAME);
     }
-    
+
+    /**
+     * @param config LDAP configuration properties
+     */
     public LDAPUserGroupCallbackImpl(Properties config) {
-        this.config = config;
-        validate();
+        super(REQUIRED_PROPERTIES, config);
     }
 
+    @Override
     public boolean existsUser(String userId) {
-        
-        InitialLdapContext ctx = null;
-        boolean exists = false;
-        try {
-            ctx = buildInitialLdapContext();
-            
-            String userContext = this.config.getProperty(USER_CTX);
-            String userFilter = this.config.getProperty(USER_FILTER);
-            String userAttrId = this.config.getProperty(USER_ATTR_ID, "uid");
-            
-            userFilter = userFilter.replaceAll("\\{0\\}", userId);
-            
-            logger.debug("Seaching for user existence with filter {} on context {}", userFilter, userContext);            
-            
-            SearchControls constraints = new SearchControls();
-            String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-            if (searchScope != null) {
-            	constraints.setSearchScope(parseSearchScope(searchScope));
-            }
-            
-            NamingEnumeration<SearchResult> result = ctx.search(userContext, userFilter, constraints);
-            if (result.hasMore()) {
-                
-                SearchResult sr = result.next();
-                Attribute ldapUserId = sr.getAttributes().get(userAttrId);
-                
-                if (ldapUserId.contains(userId)) {
-                    exists = true;
-                }
-                logger.debug("Entry in LDAP found and result of matching with given user id is {}", exists);
-                
-            }
-            result.close();
-        
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if (ctx != null) {
-                try {
-                    ctx.close();
-                } catch (NamingException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }
-        
-        return exists;
+        String context = getConfigProperty(USER_CTX);
+        String filter = getConfigProperty(USER_FILTER);
+        String attributeId = getConfigProperty(USER_ATTR_ID, DEFAULT_USER_ATTR_ID);
+
+        return existsEntity(userId, context, filter, attributeId);
     }
 
+    @Override
     public boolean existsGroup(String groupId) {
-        
-        InitialLdapContext ctx = null;
-        boolean exists = false;
-        try {
-            ctx = buildInitialLdapContext();
-            
-            String roleContext = this.config.getProperty(ROLE_CTX);
-            String roleFilter = this.config.getProperty(ROLE_FILTER);
-            String roleAttrId = this.config.getProperty(ROLE_ATTR_ID, "cn");
-            
-            roleFilter = roleFilter.replaceAll("\\{0\\}", groupId);
-            
-            SearchControls constraints = new SearchControls();
-            String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-            if (searchScope != null) {
-            	constraints.setSearchScope(parseSearchScope(searchScope));
-            }
-            
-            NamingEnumeration<SearchResult> result = ctx.search(roleContext, roleFilter, constraints);
-            if (result.hasMore()) {
-                SearchResult sr = result.next();
-                Attribute ldapUserId = sr.getAttributes().get(roleAttrId);
-                
-                if (ldapUserId.contains(groupId)) {
-                    exists = true;
-                }
-                
-            }
-            result.close();
-        
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if (ctx != null) {
-                try {
-                    ctx.close();
-                } catch (NamingException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }
-        
-        return exists;
+        String context = getConfigProperty(ROLE_CTX);
+        String filter = getConfigProperty(ROLE_FILTER);
+        String attributeId = getConfigProperty(ROLE_ATTR_ID, DEFAULT_ROLE_ATTR_ID);
+
+        return existsEntity(groupId, context, filter, attributeId);
     }
 
-    public List<String> getGroupsForUser(String userId, List<String> groupIds,
-            List<String> allExistingGroupIds) {
-       
-        InitialLdapContext ctx = null;
-        List<String> userGroups = new ArrayList<String>();
-        try {
-            ctx = buildInitialLdapContext();
-            
-            String userDN = null;
-            // if user id is not DN look it up first in ldap
-            if (!Boolean.parseBoolean(this.config.getProperty(IS_USER_ID_DN, "false"))) {
-                logger.debug("User id is not DN, looking up user first...");
-                
-                String userContext = this.config.getProperty(USER_CTX);
-                String userFilter = this.config.getProperty(USER_FILTER);
-                
-                userFilter = userFilter.replaceAll("\\{0\\}", userId);
-                SearchControls constraints = new SearchControls();
-                String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-                if (searchScope != null) {
-                	constraints.setSearchScope(parseSearchScope(searchScope));
-                }
-
-                logger.debug("Searching for user DN with filter {} on context {}", userFilter, userContext);                
-                
-                NamingEnumeration<SearchResult> result = ctx.search(userContext, userFilter, constraints);
-                if (result.hasMore()) {
-                    SearchResult searchResult = result.nextElement();
-                    userDN = searchResult.getNameInNamespace();
-                    logger.debug("User DN found, DN is {}", userDN);
-                    
-                }
-                result.close();
-            }
-            
-            String roleContext = this.config.getProperty(USER_ROLES_CTX, this.config.getProperty(ROLE_CTX));
-            String roleFilter = this.config.getProperty(USER_ROLES_FILTER);
-            String roleAttrId = this.config.getProperty(ROLE_ATTR_ID, "cn");
-            
-            roleFilter = roleFilter.replaceAll("\\{0\\}", (userDN != null ? userDN : userId));
-            SearchControls constraints = new SearchControls();
-            String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-            if (searchScope != null) {
-            	constraints.setSearchScope(parseSearchScope(searchScope));
-            }
-
-			logger.debug("Searching for groups for user with filter {} on context {}", roleFilter, roleContext);
-            
-            NamingEnumeration<SearchResult> result = ctx.search(roleContext, roleFilter, constraints);
-            if (result.hasMore()) {
-                SearchResult searchResult = null;
-                String name = null;
-                while (result.hasMore()) {
-                    searchResult = result.nextElement();
-                    name = (String) searchResult.getAttributes().get(roleAttrId).get();
-                    logger.debug("Found group {}", name);
-                    
-                    userGroups.add(name);
-                }
-            }
-            result.close();
-        
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if (ctx != null) {
-                try {
-                    ctx.close();
-                } catch (NamingException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }
-        return userGroups;
+    private boolean existsEntity(String entityId, String context, String filter, String attributeId) {
+        String ldapEntityId = ldapSearcher.search(context, filter, entityId).getSingleAttributeResult(attributeId);
+        return entityId.equals(ldapEntityId);
     }
-    
-    protected void validate() {
-        if (this.config == null) {
-            throw new IllegalArgumentException("No configuration found for LDAPUserGroupCallbackImpl, aborting...");
+
+    @Override
+    public List<String> getGroupsForUser(String userId, List<String> groupIds, List<String> allExistingGroupIds) {
+        String roleContext = getConfigProperty(USER_ROLES_CTX, getConfigProperty(ROLE_CTX));
+        String roleFilter = getConfigProperty(USER_ROLES_FILTER);
+        String roleAttributeId = getConfigProperty(ROLE_ATTR_ID, DEFAULT_ROLE_ATTR_ID);
+
+        String userDn = userId;
+        if (!isUserIdDn()) {
+            String userContext = getConfigProperty(USER_CTX);
+            String userFilter = getConfigProperty(USER_FILTER);
+
+            SearchResult searchResult = ldapSearcher.search(userContext, userFilter, userId).getSingleSearchResult();
+            userDn = searchResult.getNameInNamespace();
         }
-        StringBuffer missingRequiredProps = new StringBuffer();
-        for (String requiredProp : requiredProperties) {
-            if (!this.config.containsKey(requiredProp)) {
-                if (missingRequiredProps.length() > 0) {
-                    missingRequiredProps.append(", ");
-                }
-                missingRequiredProps.append(requiredProp);
-            }
-        }
-        
-        if (missingRequiredProps.length() > 0) {
-            logger.debug("Validation failed due to missing required properties: {}", missingRequiredProps.toString());
-            
-            throw new IllegalArgumentException("Missing required properties to configure LDAPUserGroupCallbackImpl: " + missingRequiredProps.toString());
-        }
+
+        return ldapSearcher.search(roleContext, roleFilter, userDn).getAttributeResults(roleAttributeId);
     }
-    
-    protected InitialLdapContext buildInitialLdapContext() throws NamingException {
 
-        // Set defaults for key values if they are missing
-        String factoryName = this.config.getProperty(Context.INITIAL_CONTEXT_FACTORY);
-
-        if (factoryName == null)  {
-
-            factoryName = "com.sun.jndi.ldap.LdapCtxFactory";
-            this.config.setProperty(Context.INITIAL_CONTEXT_FACTORY, factoryName);
-        }
-
-        String authType = this.config.getProperty(Context.SECURITY_AUTHENTICATION);
-
-        if (authType == null) {
-
-            this.config.setProperty(Context.SECURITY_AUTHENTICATION, "simple");
-        }
-
-        String protocol = this.config.getProperty(Context.SECURITY_PROTOCOL);
-
-        String providerURL = (String) this.config.getProperty(Context.PROVIDER_URL);
-        if (providerURL == null) {
-
-            providerURL = "ldap://localhost:"+ ((protocol != null && protocol.equals("ssl")) ? "636" : "389");
-            this.config.setProperty(Context.PROVIDER_URL, providerURL);
-        }
-        
-        String binduser = this.config.getProperty(BIND_USER); 
-
-        if (binduser != null) {
-
-            this.config.setProperty(Context.SECURITY_PRINCIPAL, binduser);
-        }
-
-        String bindpwd = this.config.getProperty(BIND_PWD); 
-
-        if (binduser != null) {
-
-            this.config.setProperty(Context.SECURITY_CREDENTIALS, bindpwd);
-        }
-        
-        if (logger.isDebugEnabled()) {
-            logger.debug("Using following InitialLdapContext properties:");
-            logger.debug("Factory {}", this.config.getProperty(Context.INITIAL_CONTEXT_FACTORY));
-            logger.debug("Authentication {}", this.config.getProperty(Context.SECURITY_AUTHENTICATION));
-            logger.debug("Protocol {}",  this.config.getProperty(Context.SECURITY_PROTOCOL));
-            logger.debug("Provider URL {}",  this.config.getProperty(Context.PROVIDER_URL));
-        }
-        
-        return new InitialLdapContext(this.config, null);
+    private boolean isUserIdDn() {
+        return Boolean.parseBoolean(getConfigProperty(IS_USER_ID_DN, DEFAULT_USER_ID_DN));
     }
-    
-	protected int parseSearchScope(String searchScope) {
-		logger.debug("Search scope: {}", searchScope);
-		if ("OBJECT_SCOPE".equals(searchScope))
-			return 0;
-		else if ("ONELEVEL_SCOPE".equals(searchScope))
-			return 1;
-		else if ("SUBTREE_SCOPE".equals(searchScope))
-			return 2;
 
-		// Default set to ONELEVEL_SCOPE
-		return 1;
-	}
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/LDAPUserInfoImpl.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/identity/LDAPUserInfoImpl.java
@@ -15,386 +15,154 @@
  */
 package org.jbpm.services.task.identity;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
-
-import javax.naming.Context;
-import javax.naming.NamingEnumeration;
-import javax.naming.NamingException;
-import javax.naming.directory.Attribute;
-import javax.naming.directory.SearchControls;
-import javax.naming.directory.SearchResult;
-import javax.naming.ldap.InitialLdapContext;
+import java.util.stream.Collectors;
 
 import org.kie.api.task.model.Group;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.User;
 import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.UserInfo;
-import org.kie.internal.task.api.model.InternalOrganizationalEntity;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-public class LDAPUserInfoImpl extends AbstractUserGroupInfo implements UserInfo {
-    
-    private static final Logger logger = LoggerFactory.getLogger(LDAPUserInfoImpl.class);
-    
-    protected static final String DEFAULT_PROPERTIES_NAME = "classpath:/jbpm.user.info.properties";
-    
-    public static final String BIND_USER = "ldap.bind.user";
-    public static final String BIND_PWD = "ldap.bind.pwd";
-    
+public class LDAPUserInfoImpl extends AbstractLDAPUserGroupInfo implements UserInfo {
+
+    private static final String DEFAULT_PROPERTIES_NAME = "jbpm.user.info";
+
     public static final String USER_CTX = "ldap.user.ctx";
     public static final String ROLE_CTX = "ldap.role.ctx";
-    
+
     public static final String USER_FILTER = "ldap.user.filter";
     public static final String ROLE_FILTER = "ldap.role.filter";
     public static final String ROLE_MEMBERS_FILTER = "ldap.role.members.filter";
-    
+
     public static final String EMAIL_ATTR_ID = "ldap.email.attr.id";
     public static final String NAME_ATTR_ID = "ldap.name.attr.id";
     public static final String LANG_ATTR_ID = "ldap.lang.attr.id";
     public static final String MEMBER_ATTR_ID = "ldap.member.attr.id";
     public static final String USER_ATTR_ID = "ldap.user.attr.id";
     public static final String ROLE_ATTR_ID = "ldap.role.attr.id";
-    
+
     public static final String IS_ENTITY_ID_DN = "ldap.entity.id.dn";
     public static final String SEARCH_SCOPE = "ldap.search.scope";
-    
-    protected static final String[] requiredProperties = {USER_CTX, ROLE_CTX, USER_FILTER, ROLE_FILTER};
 
-    
-    private Properties config;
-    
-    //no no-arg constructor to prevent cdi from auto deploy
+    private static final String[] REQUIRED_PROPERTIES = {USER_CTX, ROLE_CTX, USER_FILTER, ROLE_FILTER};
+
+    private static final String DEFAULT_EMAIL_ATTR_ID = "mail";
+    private static final String DEFAULT_ENTITY_ID_DN = "false";
+    private static final String DEFAULT_LANG_ATTR_ID = "locale";
+    private static final String DEFAULT_MEMBER_ATTR_ID = "member";
+    private static final String DEFAULT_NAME_ATTR_ID = "displayName";
+
+    private static final String DEFAULT_LOCALE = "en-UK";
+
+    /**
+     * Constructor needs to have at least one (unused) parameter in order to prevent CDI from automatic deployment.
+     * Configuration properties are loaded from a file specified by jbpm.user.info system property or
+     * classpath:/jbpm.user.info.properties file.
+     * @param activate ignored
+     */
     public LDAPUserInfoImpl(boolean activate) {
-        String propertiesLocation = System.getProperty("jbpm.user.info.properties");
-        
-        config = readProperties(propertiesLocation, DEFAULT_PROPERTIES_NAME);
-        validate();
+        super(REQUIRED_PROPERTIES, DEFAULT_PROPERTIES_NAME);
     }
-    
+
+    /**
+     * @param config LDAP configuration properties
+     */
     public LDAPUserInfoImpl(Properties config) {
-        this.config = config;
-        validate();
+        super(REQUIRED_PROPERTIES, config);
     }
 
+    @Override
     public String getDisplayName(OrganizationalEntity entity) {
-        String context = null;
-        String filter = null;
-        String attrId = null;
-        if (entity instanceof User) {
-            context = this.config.getProperty(USER_CTX);
-            filter = this.config.getProperty(USER_FILTER);
-            attrId = this.config.getProperty(NAME_ATTR_ID, "displayName");
-        } else if (entity instanceof Group) {
-            context = this.config.getProperty(ROLE_CTX);
-            filter = this.config.getProperty(ROLE_FILTER);
-            attrId = this.config.getProperty(NAME_ATTR_ID, "displayName");
-        } else {
-            throw new IllegalArgumentException("Unknown organizational entity " + entity);
-        }
-        String result = searchLdap(context, filter, attrId, entity);
-        
-        return result;
+        return getAttributeValueForEntity(entity, NAME_ATTR_ID, DEFAULT_NAME_ATTR_ID);
     }
 
+    @Override
     public Iterator<OrganizationalEntity> getMembersForGroup(Group group) {
-        InitialLdapContext ctx = null;
-        List<OrganizationalEntity> memebers = new ArrayList<OrganizationalEntity>();
-        try {
-            ctx = buildInitialLdapContext();
-            
-            String roleContext = this.config.getProperty(ROLE_CTX);
-            String roleFilter = this.config.getProperty(ROLE_MEMBERS_FILTER, this.config.getProperty(ROLE_FILTER));
-            String roleAttrId = this.config.getProperty(MEMBER_ATTR_ID, "member");
-            
-            String entityId = group.getId();
-            if (Boolean.parseBoolean(this.config.getProperty(IS_ENTITY_ID_DN, "false"))) {
-                entityId = extractUserId(entityId, group);
-            }
-            
-            roleFilter = roleFilter.replaceAll("\\{0\\}", entityId);
-            
-            SearchControls constraints = new SearchControls();
-            String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-            if (searchScope != null) {
-            	constraints.setSearchScope(parseSearchScope(searchScope));
-            }
-            
-            NamingEnumeration<SearchResult> result = ctx.search(roleContext, roleFilter, constraints);
-            while (result.hasMore()) {
-                SearchResult sr = result.next();
-                Attribute member = sr.getAttributes().get(roleAttrId);
-                for (int i = 0; i < member.size(); i++) {
-                	User user = TaskModelProvider.getFactory().newUser();
-                    ((InternalOrganizationalEntity) user).setId(member.get(i).toString());
-                    memebers.add(user);
-                }
-                
-            }
-            result.close();
-        
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if (ctx != null) {
-                try {
-                    ctx.close();
-                } catch (NamingException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }
-        return memebers.iterator();
+        String roleContext = getConfigProperty(ROLE_CTX);
+        String roleFilter = getConfigProperty(ROLE_MEMBERS_FILTER, getConfigProperty(ROLE_FILTER));
+        String roleAttrId = getConfigProperty(MEMBER_ATTR_ID, DEFAULT_MEMBER_ATTR_ID);
+
+        String entityId = extractEntityId(group);
+
+        List<String> memberIds = ldapSearcher.search(roleContext, roleFilter, entityId).getAttributeResults(roleAttrId);
+        return memberIds.stream()
+                .filter(memberId -> memberId != null)
+                .map(memberId -> (OrganizationalEntity) TaskModelProvider.getFactory().newUser(memberId))
+                .collect(Collectors.toList())
+                .iterator();
     }
 
+    @Override
     public boolean hasEmail(Group group) {
-        InitialLdapContext ctx = null;
-        boolean exists = false;
-        try {
-            ctx = buildInitialLdapContext();
-            
-            String roleContext = this.config.getProperty(ROLE_CTX);
-            String roleFilter = this.config.getProperty(ROLE_FILTER);
-            String roleAttrId = this.config.getProperty(EMAIL_ATTR_ID, "mail");
-            
-            String entityId = group.getId();
-            if (Boolean.parseBoolean(this.config.getProperty(IS_ENTITY_ID_DN, "false"))) {
-                entityId = extractUserId(entityId, group);
-            }
-            
-            roleFilter = roleFilter.replaceAll("\\{0\\}", entityId);
-            
-            SearchControls constraints = new SearchControls();
-            String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-            if (searchScope != null) {
-            	constraints.setSearchScope(parseSearchScope(searchScope));
-            }
-            
-            NamingEnumeration<SearchResult> result = ctx.search(roleContext, roleFilter, constraints);
-            if (result.hasMore()) {
-                SearchResult sr = result.next();
-                Attribute ldapGroupEmail = sr.getAttributes().get(roleAttrId);
-                
-                if (ldapGroupEmail != null && ldapGroupEmail.get() != null) {
-                    exists = true;
-                }
-                
-            }
-            result.close();
-        
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if (ctx != null) {
-                try {
-                    ctx.close();
-                } catch (NamingException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }
-        return exists;
+        return getEmailForEntity(group) != null;
     }
 
+    @Override
     public String getEmailForEntity(OrganizationalEntity entity) {
-        String context = null;
-        String filter = null;
-        String attrId = null;
-        if (entity instanceof User) {
-            context = this.config.getProperty(USER_CTX);
-            filter = this.config.getProperty(USER_FILTER);
-            attrId = this.config.getProperty(EMAIL_ATTR_ID, "mail");
-        } else if (entity instanceof Group) {
-            context = this.config.getProperty(ROLE_CTX);
-            filter = this.config.getProperty(ROLE_FILTER);
-            attrId = this.config.getProperty(EMAIL_ATTR_ID, "mail");
-        } else {
-            throw new IllegalArgumentException("Unknown organizational entity " + entity);
-        }
-        String result = searchLdap(context, filter, attrId, entity);
-        
-        return result;
+        return getAttributeValueForEntity(entity, EMAIL_ATTR_ID, DEFAULT_EMAIL_ATTR_ID);
     }
 
+    @Override
     public String getLanguageForEntity(OrganizationalEntity entity) {
-        String context = null;
-        String filter = null;
-        String attrId = null;
+        String result = getAttributeValueForEntity(entity, LANG_ATTR_ID, DEFAULT_LANG_ATTR_ID);
+        return result == null ? DEFAULT_LOCALE : result;
+    }
+
+    private String getAttributeValueForEntity(OrganizationalEntity entity, String attributeName, String defaultValue) {
+        String context = getConfigPropertyByEntity(entity, USER_CTX, ROLE_CTX);
+        String filter = getConfigPropertyByEntity(entity, USER_FILTER, ROLE_FILTER);
+        String attrId = getConfigProperty(attributeName, defaultValue);
+
+        String entityId = extractEntityId(entity);
+
+        return ldapSearcher.search(context, filter, entityId).getSingleAttributeResult(attrId);
+    }
+
+    private String getConfigPropertyByEntity(OrganizationalEntity entity, String userKey, String roleKey) {
         if (entity instanceof User) {
-            context = this.config.getProperty(USER_CTX);
-            filter = this.config.getProperty(USER_FILTER);
-            attrId = this.config.getProperty(LANG_ATTR_ID, "locale");
+            return getConfigProperty(userKey);
         } else if (entity instanceof Group) {
-            context = this.config.getProperty(ROLE_CTX);
-            filter = this.config.getProperty(ROLE_FILTER);
-            attrId = this.config.getProperty(LANG_ATTR_ID, "locale");
+            return getConfigProperty(roleKey);
         } else {
-            throw new IllegalArgumentException("Unknown organizational entity " + entity);
-        }
-        String result = searchLdap(context, filter, attrId, entity);
-        if (result == null) {
-            // defaults to en-UK
-            result = "en-UK";
-        }
-        return result;
-    }
-    
-    protected void validate() {
-        if (this.config == null) {
-            throw new IllegalArgumentException("No configuration found for LDAPUserInfoImpl, aborting...");
-        }
-        StringBuffer missingRequiredProps = new StringBuffer();
-        for (String requiredProp : requiredProperties) {
-            if (!this.config.containsKey(requiredProp)) {
-                if (missingRequiredProps.length() > 0) {
-                    missingRequiredProps.append(", ");
-                }
-                missingRequiredProps.append(requiredProp);
-            }
-        }
-        
-        if (missingRequiredProps.length() > 0) {
-            logger.debug("Validation failed due to missing required properties: {}", missingRequiredProps.toString());
-            
-            throw new IllegalArgumentException("Missing required properties to configure LDAPUserInfoImpl: " + missingRequiredProps.toString());
+            throw new IllegalArgumentException("Unknown organizational entity: " + entity);
         }
     }
-    
-    protected InitialLdapContext buildInitialLdapContext() throws NamingException {
 
-        // Set defaults for key values if they are missing
-        String factoryName = this.config.getProperty(Context.INITIAL_CONTEXT_FACTORY);
-
-        if (factoryName == null)  {
-
-            factoryName = "com.sun.jndi.ldap.LdapCtxFactory";
-            this.config.setProperty(Context.INITIAL_CONTEXT_FACTORY, factoryName);
+    private String extractEntityId(OrganizationalEntity entity) {
+        if (!isEntityIdDn()) {
+            return entity.getId();
         }
 
-        String authType = this.config.getProperty(Context.SECURITY_AUTHENTICATION);
+        String entityDN = entity.getId();
+        String[] attributes = entityDN.split(",");
 
-        if (authType == null) {
-
-            this.config.setProperty(Context.SECURITY_AUTHENTICATION, "simple");
-        }
-
-        String protocol = this.config.getProperty(Context.SECURITY_PROTOCOL);
-
-        String providerURL = (String) this.config.getProperty(Context.PROVIDER_URL);
-        if (providerURL == null) {
-
-            providerURL = "ldap://localhost:"+ ((protocol != null && protocol.equals("ssl")) ? "636" : "389");
-            this.config.setProperty(Context.PROVIDER_URL, providerURL);
-        }
-        
-        String binduser = this.config.getProperty(BIND_USER); 
-
-        if (binduser != null) {
-
-            this.config.setProperty(Context.SECURITY_PRINCIPAL, binduser);
-        }
-
-        String bindpwd = this.config.getProperty(BIND_PWD); 
-
-        if (binduser != null) {
-
-            this.config.setProperty(Context.SECURITY_CREDENTIALS, bindpwd);
-        }
-
-        if (logger.isDebugEnabled()) {
-            logger.debug("Using following InitialLdapContext properties:");
-            logger.debug("Factory {}", this.config.getProperty(Context.INITIAL_CONTEXT_FACTORY));
-            logger.debug("Authentication {}", this.config.getProperty(Context.SECURITY_AUTHENTICATION));
-            logger.debug("Protocol {}",  this.config.getProperty(Context.SECURITY_PROTOCOL));
-            logger.debug("Provider URL {}",  this.config.getProperty(Context.PROVIDER_URL));
-        }
-        
-        return new InitialLdapContext(this.config, null);
-    }
-    
-    protected String searchLdap(String context, String filter, String attrId, OrganizationalEntity entity) {
-        InitialLdapContext ctx = null;
-        String result = null;
-        try {
-            ctx = buildInitialLdapContext();
-            String entityId =  entity.getId();
-            if (Boolean.parseBoolean(this.config.getProperty(IS_ENTITY_ID_DN, "false"))) {
-                entityId = extractUserId(entityId, entity);
-            }
-            filter = filter.replaceAll("\\{0\\}",entityId);
-            
-            SearchControls constraints = new SearchControls();
-            String searchScope  = this.config.getProperty(SEARCH_SCOPE);
-            if (searchScope != null) {
-            	constraints.setSearchScope(parseSearchScope(searchScope));
-            }
-            
-            NamingEnumeration<SearchResult> ldapResult = ctx.search(context, filter, constraints);
-            if (ldapResult.hasMore()) {
-                SearchResult sr = ldapResult.next();
-                Attribute entry = sr.getAttributes().get(attrId);
-                if (entry != null) {
-                    result = (String) entry.get();
-                }
-                
-            }
-            ldapResult.close();
-        
-        } catch (Exception e) {
-            e.printStackTrace();
-        }finally {
-            if (ctx != null) {
-                try {
-                    ctx.close();
-                } catch (NamingException e) {
-                    e.printStackTrace();
-                }
-            }
-            
-        }
-        return result;
-    }
-    
-    protected String extractUserId(String userDN, OrganizationalEntity entity) {
-        String[] attributes = userDN.split(",");
-        
         if (attributes.length == 1) {
-            return userDN;
+            return entityDN;
         }
+
         String entityAttrId = null;
         if (entity instanceof User) {
-            entityAttrId = this.config.getProperty(USER_ATTR_ID, "uid");
+            entityAttrId = getConfigProperty(USER_ATTR_ID, DEFAULT_USER_ATTR_ID);
         } else if (entity instanceof Group) {
-            entityAttrId = this.config.getProperty(ROLE_ATTR_ID, "cn");
+            entityAttrId = getConfigProperty(ROLE_ATTR_ID, DEFAULT_ROLE_ATTR_ID);
         }
-        if (attributes != null) {
-            for (String attribute : attributes) {
-                String[] keyValue = attribute.split("=");
-                
-                if (keyValue[0].equalsIgnoreCase(entityAttrId)) {
-                    return keyValue[1];
-                }
+
+        for (String attribute : attributes) {
+            String[] keyValue = attribute.split("=");
+
+            if (keyValue[0].equalsIgnoreCase(entityAttrId)) {
+                return keyValue[1];
             }
         }
-        return null;
-    }
-    
-	protected int parseSearchScope(String searchScope) {
-		logger.debug("Search scope: {}", searchScope);
-		if ("OBJECT_SCOPE".equals(searchScope))
-			return 0;
-		else if ("ONELEVEL_SCOPE".equals(searchScope))
-			return 1;
-		else if ("SUBTREE_SCOPE".equals(searchScope))
-			return 2;
 
-		// Default set to ONELEVEL_SCOPE
-		return 1;
-	}
+        throw new RuntimeException("Cannot parse '" + entityAttrId + "' attribute from entity DN '" + entityDN + "'");
+    }
+
+    private boolean isEntityIdDn() {
+        return Boolean.parseBoolean(getConfigProperty(IS_ENTITY_ID_DN, DEFAULT_ENTITY_ID_DN));
+    }
+
 }

--- a/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/utils/LdapSearcher.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/main/java/org/jbpm/services/task/utils/LdapSearcher.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.jbpm.services.task.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.directory.Attribute;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class providing LDAP search capabilities.
+ */
+public class LdapSearcher {
+
+    private static final Logger log = LoggerFactory.getLogger(LdapSearcher.class);
+
+    public static final String SEARCH_SCOPE = "ldap.search.scope";
+
+    private static final String DEFAULT_INITIAL_CONTEXT_FACTORY = "com.sun.jndi.ldap.LdapCtxFactory";
+    private static final String DEFAULT_SECURITY_AUTHENTICATION = "simple";
+
+    private final List<SearchResult> searchResults = new ArrayList<>();
+
+    private final Properties config;
+
+    /**
+     * @param config LDAP connection properties
+     * @see javax.naming.Context
+     */
+    public LdapSearcher(Properties config) {
+        this.config = config;
+    }
+
+    /**
+     * Search LDAP and stores the results in searchResults field.
+     * @param context the name of the context where the search starts (the depth depends on ldap.search.scope)
+     * @param filterExpr the filter expression to use for the search. The expression may contain variables of the form
+     * "<code>{i}</code>" where <code>i</code> is a non-negative integer. May not be null.
+     * @param filterArgs the array of arguments to substitute for the variables in <code>filterExpr</code>. The value of
+     * <code>filterArgs[i]</code> will replace each occurrence of "<code>{i}</code>". If null, an equivalent of an empty
+     * array is used.
+     * @return this
+     */
+    public LdapSearcher search(String context, String filterExpr, Object... filterArgs) {
+        searchResults.clear();
+
+        LdapContext ldapContext = null;
+        NamingEnumeration<SearchResult> ldapResult = null;
+        try {
+            ldapContext = buildLdapContext();
+            ldapResult = ldapContext.search(context, filterExpr, filterArgs, createSearchControls());
+            while (ldapResult.hasMore()) {
+                searchResults.add(ldapResult.next());
+            }
+        } catch (NamingException ex) {
+            throw new RuntimeException("LDAP search has failed", ex);
+        } finally {
+            if (ldapResult != null) {
+                try {
+                    ldapResult.close();
+                } catch (NamingException ex) {
+                    log.error("Failed to close LDAP results enumeration", ex);
+                }
+            }
+            if (ldapContext != null) {
+                try {
+                    ldapContext.close();
+                } catch (NamingException ex) {
+                    log.error("Failed to close LDAP context", ex);
+                }
+            }
+        }
+
+        return this;
+    }
+
+    public SearchResult getSingleSearchResult() {
+        return searchResults.isEmpty() ? null : searchResults.get(0);
+    }
+
+    public List<SearchResult> getSearchResults() {
+        return searchResults;
+    }
+
+    public String getSingleAttributeResult(String attributeId) {
+        List<String> attributeResults = getAttributeResults(attributeId);
+        return attributeResults.isEmpty() ? null : attributeResults.get(0);
+    }
+
+    public List<String> getAttributeResults(String attributeId) {
+        return searchResults.stream()
+                .map(searchResult -> getAttribute(searchResult, attributeId))
+                .collect(Collectors.toList());
+    }
+
+    private String getAttribute(SearchResult searchResult, String attributeId) {
+        if (searchResult == null) {
+            return null;
+        }
+
+        Attribute entry = searchResult.getAttributes().get(attributeId);
+
+        if (entry == null) {
+            log.warn("The attribute with ID '{}' has not been found.", attributeId);
+            return null;
+        }
+
+        try {
+            return entry.get().toString();
+        } catch (NamingException ex) {
+            log.error("Failed to get attribute value", ex);
+            return null;
+        }
+    }
+
+    private LdapContext buildLdapContext() throws NamingException {
+        config.putIfAbsent(Context.INITIAL_CONTEXT_FACTORY, DEFAULT_INITIAL_CONTEXT_FACTORY);
+        config.putIfAbsent(Context.SECURITY_AUTHENTICATION, DEFAULT_SECURITY_AUTHENTICATION);
+
+        String protocol = config.getProperty(Context.SECURITY_PROTOCOL);
+        config.putIfAbsent(Context.PROVIDER_URL, createDefaultProviderUrl(protocol));
+
+        if (log.isDebugEnabled()) {
+            log.debug("Using following InitialLdapContext properties:");
+            log.debug("Initial Context Factory: {}", config.getProperty(Context.INITIAL_CONTEXT_FACTORY));
+            log.debug("Authentication Type: {}", config.getProperty(Context.SECURITY_AUTHENTICATION));
+            log.debug("Protocol: {}", config.getProperty(Context.SECURITY_PROTOCOL));
+            log.debug("Provider URL: {}", config.getProperty(Context.PROVIDER_URL));
+            log.debug("User DN: {}", config.getProperty(Context.SECURITY_PRINCIPAL));
+            log.debug("Password: {}", config.getProperty(Context.SECURITY_CREDENTIALS));
+        }
+
+        return new InitialLdapContext(config, null);
+    }
+
+    private String createDefaultProviderUrl(String protocol) {
+        String port = "ssl".equalsIgnoreCase(protocol) ? "636" : "389";
+        return "ldap://localhost:" + port;
+    }
+
+    private SearchControls createSearchControls() {
+        SearchControls searchControls = new SearchControls();
+
+        String searchScope = config.getProperty(SEARCH_SCOPE);
+        if (searchScope != null) {
+            searchControls.setSearchScope(parseSearchScope(searchScope));
+        }
+
+        return searchControls;
+    }
+
+    private int parseSearchScope(String searchScope) {
+        log.debug("Search scope: {}", searchScope);
+
+        try {
+            return SearchScope.valueOf(searchScope).ordinal();
+        } catch (IllegalArgumentException ex) {
+            return SearchScope.ONELEVEL_SCOPE.ordinal();
+        }
+    }
+
+    public enum SearchScope {
+        OBJECT_SCOPE, ONELEVEL_SCOPE, SUBTREE_SCOPE
+    }
+
+}

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPBaseTest.java
@@ -26,27 +26,26 @@ import org.junit.Before;
 
 public abstract class LDAPBaseTest {
 
-    public enum SearchScope {
+    private static final int PORT = 10389;
 
-        OBJECT_SCOPE, ONELEVEL_SCOPE, SUBTREE_SCOPE
-
-    }
+    protected static final String SERVER_URL = "ldap://localhost:" + PORT;
+    protected static final String BASE_DN = "dc=jbpm,dc=org";
+    protected static final String USER_DN = "uid=admin,ou=system";
+    protected static final String PASSWORD = "secret";
 
     public enum Configuration {
-
         CUSTOM, DEFAULT, SYSTEM
-
     }
 
     private InMemoryDirectoryServer server;
 
     @Before
     public void startDirectoryServer() throws LDAPException {
-        InMemoryListenerConfig listenerConfig = InMemoryListenerConfig.createLDAPConfig("default", 10389);
+        InMemoryListenerConfig listenerConfig = InMemoryListenerConfig.createLDAPConfig("default", PORT);
 
-        InMemoryDirectoryServerConfig serverConfig = new InMemoryDirectoryServerConfig(new DN("dc=jbpm,dc=org"));
+        InMemoryDirectoryServerConfig serverConfig = new InMemoryDirectoryServerConfig(new DN(BASE_DN));
         serverConfig.setListenerConfigs(listenerConfig);
-        serverConfig.addAdditionalBindCredentials("uid=admin,ou=system", "secret");
+        serverConfig.addAdditionalBindCredentials(USER_DN, PASSWORD);
         serverConfig.setSchema(null);
 
         server = new InMemoryDirectoryServer(serverConfig);

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserGroupCallbackImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserGroupCallbackImplTest.java
@@ -15,12 +15,13 @@
 
 package org.jbpm.services.task.identity;
 
-import javax.naming.Context;
 import java.util.List;
 import java.util.Properties;
+import javax.naming.Context;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
+import org.jbpm.services.task.utils.LdapSearcher.SearchScope;
 import org.junit.After;
 import org.junit.Test;
 import org.kie.api.task.UserGroupCallback;
@@ -284,7 +285,7 @@ public class LDAPUserGroupCallbackImplTest extends LDAPBaseTest {
 
     private Properties createUserGroupCallbackProperties() {
         Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
+        properties.setProperty(Context.PROVIDER_URL, SERVER_URL);
         properties.setProperty(LDAPUserGroupCallbackImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserGroupCallbackImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserGroupCallbackImpl.USER_FILTER, "(uid={0})");
@@ -325,7 +326,7 @@ public class LDAPUserGroupCallbackImplTest extends LDAPBaseTest {
     }
 
     private void assertUsers(UserGroupCallback userGroupCallback, boolean john, boolean mary, boolean peter,
-            boolean mike) {
+                             boolean mike) {
         Assertions.assertThat(userGroupCallback).isNotNull();
 
         SoftAssertions assertions = new SoftAssertions();
@@ -337,7 +338,7 @@ public class LDAPUserGroupCallbackImplTest extends LDAPBaseTest {
     }
 
     private void assertGroups(UserGroupCallback userGroupCallback, boolean manager, boolean user, boolean analyst,
-            boolean developer) {
+                              boolean developer) {
         Assertions.assertThat(userGroupCallback).isNotNull();
 
         SoftAssertions assertions = new SoftAssertions();

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserInfoImplTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/identity/LDAPUserInfoImplTest.java
@@ -15,23 +15,21 @@
 
 package org.jbpm.services.task.identity;
 
-import static org.jbpm.services.task.identity.LDAPBaseTest.SearchScope.OBJECT_SCOPE;
-import static org.jbpm.services.task.identity.LDAPBaseTest.SearchScope.ONELEVEL_SCOPE;
-import static org.jbpm.services.task.identity.LDAPBaseTest.SearchScope.SUBTREE_SCOPE;
-
 import java.util.Iterator;
 import java.util.Properties;
-
 import javax.naming.Context;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.api.SoftAssertions;
+import org.jbpm.services.task.utils.LdapSearcher.SearchScope;
 import org.junit.Test;
 import org.kie.api.task.model.Group;
 import org.kie.api.task.model.OrganizationalEntity;
 import org.kie.api.task.model.User;
 import org.kie.internal.task.api.TaskModelProvider;
 import org.kie.internal.task.api.UserInfo;
+
+import static org.jbpm.services.task.utils.LdapSearcher.SearchScope.*;
 
 public class LDAPUserInfoImplTest extends LDAPBaseTest {
 
@@ -51,7 +49,7 @@ public class LDAPUserInfoImplTest extends LDAPBaseTest {
 
     private Properties createUserInfoProperties() {
         Properties properties = new Properties();
-        properties.setProperty(Context.PROVIDER_URL, "ldap://localhost:10389");
+        properties.setProperty(Context.PROVIDER_URL, SERVER_URL);
         properties.setProperty(LDAPUserInfoImpl.USER_CTX, "ou=People,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserInfoImpl.ROLE_CTX, "ou=Roles,dc=jbpm,dc=org");
         properties.setProperty(LDAPUserInfoImpl.USER_FILTER, "(uid={0})");
@@ -157,7 +155,7 @@ public class LDAPUserInfoImplTest extends LDAPBaseTest {
         testGetMembersForGroup(false, false, false);
     }
 
-    
+
     @Test
     public void testGetMembersForGroupDnByDefaultAttribute() {
         testGetMembersForGroup(false, false, true);
@@ -167,7 +165,7 @@ public class LDAPUserInfoImplTest extends LDAPBaseTest {
     public void testGetMembersForGroupByCustomAttribute() {
         testGetMembersForGroup(false, true, false);
     }
-    
+
     @Test
     public void testGetMembersForGroupDnByCustomAttribute() {
         testGetMembersForGroup(false, true, true);
@@ -201,7 +199,7 @@ public class LDAPUserInfoImplTest extends LDAPBaseTest {
         testHasEmail(MANAGER, true, false);
     }
 
-    
+
     @Test
     public void testHasExistingEmailDnByDefaultAttribute() {
         testHasEmail(MANAGER_DN, true, false);
@@ -212,7 +210,7 @@ public class LDAPUserInfoImplTest extends LDAPBaseTest {
         testHasEmail(USER, true, true);
     }
 
-    
+
     @Test
     public void testHasExistingEmailDnByCustomAttribute() {
         testHasEmail(USER_DN, true, true);

--- a/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/utils/LdapSearcherTest.java
+++ b/jbpm-human-task/jbpm-human-task-core/src/test/java/org/jbpm/services/task/utils/LdapSearcherTest.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package org.jbpm.services.task.utils;
+
+import java.util.List;
+import java.util.Properties;
+import javax.naming.AuthenticationException;
+import javax.naming.CommunicationException;
+import javax.naming.Context;
+import javax.naming.InvalidNameException;
+import javax.naming.NameNotFoundException;
+import javax.naming.NamingException;
+import javax.naming.directory.InvalidSearchFilterException;
+import javax.naming.directory.SearchResult;
+
+import org.assertj.core.api.Assertions;
+import org.jbpm.services.task.identity.LDAPBaseTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.jbpm.services.task.utils.LdapSearcher.*;
+
+public class LdapSearcherTest extends LDAPBaseTest {
+
+    private static final String CONTEXT = "ou=People,dc=jbpm,dc=org";
+    private static final String FILTER = "(uid=*)";
+
+    private Properties config;
+
+    @Before
+    public void prepareDefaultConfiguration() {
+        config = new Properties();
+        config.setProperty(Context.PROVIDER_URL, SERVER_URL);
+        config.setProperty(Context.SECURITY_PRINCIPAL, USER_DN);
+        config.setProperty(Context.SECURITY_CREDENTIALS, PASSWORD);
+    }
+
+    private void testInvalidSearch(Class<? extends Exception> exceptionClass) {
+        testInvalidSearch(exceptionClass, CONTEXT, FILTER);
+    }
+
+    private void testInvalidSearch(Class<? extends Exception> exceptionClass, String context, String filter) {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        try {
+            ldapSearcher.search(context, filter);
+            Assertions.fail(exceptionClass.getName() + " should have been thrown");
+        } catch (RuntimeException ex) {
+            assertThat(ex).hasCauseInstanceOf(exceptionClass);
+        }
+    }
+
+    @Test
+    public void testSearchInvalidUrl() {
+        config.setProperty(Context.PROVIDER_URL, "ldap://localhost:1389");
+
+        testInvalidSearch(CommunicationException.class);
+    }
+
+    @Test
+    public void testSearchInvalidUsername() {
+        config.setProperty(Context.SECURITY_PRINCIPAL, "admin");
+
+        testInvalidSearch(InvalidNameException.class);
+    }
+
+    @Test
+    public void testSearchWrongPassword() {
+        config.setProperty(Context.SECURITY_CREDENTIALS, "password");
+
+        testInvalidSearch(AuthenticationException.class);
+    }
+
+    @Test
+    public void testSearchNotExistingContext() {
+        testInvalidSearch(NameNotFoundException.class, "ou=Animals,dc=jbpm,dc=org", FILTER);
+    }
+
+    @Test
+    public void testSearchEmptyFilter() {
+        testInvalidSearch(InvalidSearchFilterException.class, CONTEXT, "");
+    }
+
+    @Test
+    public void testSearchWithFilterArgumentWithoutValue() {
+        testInvalidSearch(InvalidSearchFilterException.class, CONTEXT, "(uid={0})");
+    }
+
+    @Test
+    public void testSearchWithoutFilterArguments() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        List<SearchResult> searchResults = ldapSearcher.search(CONTEXT, "(uid=john)").getSearchResults();
+
+        assertThat(searchResults).isNotEmpty().hasSize(1);
+    }
+
+    @Test
+    public void testSearchWithOneFilterArgument() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        List<SearchResult> searchResults = ldapSearcher.search(CONTEXT, "(uid={0})", "john").getSearchResults();
+
+        assertThat(searchResults).isNotEmpty().hasSize(1);
+    }
+
+    @Test
+    public void testSearchWithTwoFilterArguments() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        List<SearchResult> searchResults = ldapSearcher.search(CONTEXT, "(|(uid={0})(uid={1}))", "john", "mary")
+                .getSearchResults();
+
+        assertThat(searchResults).isNotEmpty().hasSize(2);
+    }
+
+    @Test
+    public void testGetSingleSearchResult() throws NamingException {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        SearchResult searchResult = ldapSearcher.search(CONTEXT, "(uid=john)").getSingleSearchResult();
+
+        assertThat(searchResult).isNotNull();
+        assertThat(searchResult.getAttributes().get("uid").get()).isEqualTo("john");
+    }
+
+    @Test
+    public void testGetSingleSearchResultEmpty() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        SearchResult searchResult = ldapSearcher.search(CONTEXT, "(uid=peter)").getSingleSearchResult();
+
+        assertThat(searchResult).isNull();
+    }
+
+    @Test
+    public void testGetSingleSearchResultFromMultiple() throws NamingException {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        SearchResult searchResult = ldapSearcher.search(CONTEXT, "(uid=*)").getSingleSearchResult();
+
+        assertThat(searchResult).isNotNull();
+        assertThat(searchResult.getAttributes().get("uid").get()).isEqualTo("john");
+    }
+
+    private void testGetSearchResults(SearchScope searchScope, String... expectedUsers) {
+        if (searchScope != null) {
+            config.setProperty(LdapSearcher.SEARCH_SCOPE, searchScope.name());
+        }
+
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        List<SearchResult> searchResults = ldapSearcher.search(CONTEXT, "(uid=*)").getSearchResults();
+
+        assertThat(searchResults).extracting(searchResult -> {
+            try {
+                return searchResult.getAttributes().get("uid").get();
+            } catch (NamingException ex) {
+                throw new RuntimeException(ex);
+            }
+        }).containsOnly(expectedUsers);
+    }
+
+    @Test
+    public void testGetSearchResultsObjectScope() throws NamingException {
+        testGetSearchResults(SearchScope.OBJECT_SCOPE);
+    }
+
+    @Test
+    public void testGetSearchResultsDefaultScope() throws NamingException {
+        testGetSearchResults(null, "john", "mary");
+    }
+
+    @Test
+    public void testGetSearchResultsOneLevelScope() throws NamingException {
+        testGetSearchResults(SearchScope.ONELEVEL_SCOPE, "john", "mary");
+    }
+
+    @Test
+    public void testGetSearchResultsSubtreeScope() {
+        testGetSearchResults(SearchScope.SUBTREE_SCOPE, "john", "mary", "peter", "mike");
+    }
+
+    @Test
+    public void testGetSingleAttributeResult() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        String attributeResult = ldapSearcher.search(CONTEXT, "(uid=john)").getSingleAttributeResult("uid");
+
+        assertThat(attributeResult).isNotNull().isEqualTo("john");
+    }
+
+    @Test
+    public void testGetSingleAttributeResultEmpty() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        String attributeResult = ldapSearcher.search(CONTEXT, "(uid=peter)").getSingleAttributeResult("uid");
+
+        assertThat(attributeResult).isNull();
+    }
+
+    @Test
+    public void testGetSingleAttributeFromMultiple() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        String attributeResult = ldapSearcher.search(CONTEXT, "(uid=*)").getSingleAttributeResult("uid");
+
+        assertThat(attributeResult).isNotNull().isEqualTo("john");
+    }
+
+    @Test
+    public void testGetSingleAttributeResultNotExistingAttribute() {
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        String attributeResult = ldapSearcher.search(CONTEXT, "(uid=john)").getSingleAttributeResult("xyz");
+
+        assertThat(attributeResult).isNull();
+    }
+
+    private void testGetAttributeResults(SearchScope searchScope, String... expectedUsers) {
+        if (searchScope != null) {
+            config.setProperty(LdapSearcher.SEARCH_SCOPE, searchScope.name());
+        }
+
+        LdapSearcher ldapSearcher = new LdapSearcher(config);
+        List<String> attributeResults = ldapSearcher.search(CONTEXT, "(uid=*)").getAttributeResults("uid");
+
+        assertThat(attributeResults).containsOnly(expectedUsers);
+    }
+
+    @Test
+    public void testGetAttributeResultsObjectScope() {
+        testGetAttributeResults(SearchScope.OBJECT_SCOPE);
+    }
+
+    @Test
+    public void testGetAttributeResultsDefaultScope() {
+        testGetAttributeResults(null, "john", "mary");
+    }
+
+    @Test
+    public void testGetAttributeResultsOneLevelScope() {
+        testGetAttributeResults(SearchScope.ONELEVEL_SCOPE, "john", "mary");
+    }
+
+    @Test
+    public void testGetAttributeResultsSubtreeScope() {
+        testGetAttributeResults(SearchScope.SUBTREE_SCOPE, "john", "mary", "peter", "mike");
+    }
+
+}


### PR DESCRIPTION
Both LDAPUserGroupCallbackImpl and LDAPUserInfoImpl classes contained very long methods with many code duplicates which made it really hard to understand how exactly they worked.

I have refactored them and extracted the logic dealing directly with LDAP to LdapSearcher class as well as their common setup to AbstractLDAPUserGroupInfo. I have not changed the behavior of LDAPUserGroupCallbackImpl or LDAPUserInfoImpl. Both of them are covered by a lot of tests which as you can see have not been changed at all.

The only thing that has been changed is `ldap.roles.attr.id` configuration property in LDAPUserGroupCallbackImpl which is now `ldap.role.attr.id`. I think there was a typo in the previous version and since we are working on the next major version we do not have to care about backward compatibility too much.