### PR TITLE
query-jpa: explicitly depend on jboss-jaxb-api_2.2_spec

### DIFF
--- a/jbpm-query-jpa/pom.xml
+++ b/jbpm-query-jpa/pom.xml
@@ -102,7 +102,13 @@
       <artifactId>org.osgi.compendium</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.jboss.spec.javax.xml.bind</groupId>
+      <artifactId>jboss-jaxb-api_2.2_spec</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- logging --> 
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
 * the API is exposed by Java 8 by default, but not by
   Java 9. Marking the dependency as provided to not
   change the current behavior