### PR TITLE
JBPM-5204 Redundant DB calls when Pessimistic locking is used

### DIFF
--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/JPATaskPersistenceContext.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/persistence/JPATaskPersistenceContext.java
@@ -109,7 +109,7 @@ public class JPATaskPersistenceContext implements TaskPersistenceContext {
 		check();
 		Task task = null;
 		if( this.pessimisticLocking ) {
-			task = this.em.find( TaskImpl.class, taskId, LockModeType.PESSIMISTIC_FORCE_INCREMENT );
+			return this.em.find( TaskImpl.class, taskId, LockModeType.PESSIMISTIC_FORCE_INCREMENT );
         }
 		task = this.em.find( TaskImpl.class, taskId );
 		return task;


### PR DESCRIPTION
no unit test created - the tests for this functionality are already there, and they should be still passing after this change.