### PR TITLE
Increate test timeout to stabilize test on slower CI machines

### DIFF
--- a/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskCallbackTest.java
+++ b/jbpm-test-coverage/src/test/java/org/jbpm/test/functional/jobexec/AsyncTaskCallbackTest.java
@@ -72,7 +72,7 @@ public class AsyncTaskCallbackTest extends JbpmAsyncJobTestCase {
         }
     }
 
-    @Test(timeout=10000)
+    @Test(timeout=30000)
     public void testTaskCallback() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("Continue", 1);
         addProcessEventListener(countDownListener);


### PR DESCRIPTION
 * the test timeouts quite regularly on slower Jenkins machines.
   Increasing the timeout will show us if the test simply
   timeouts because of that; or if there is some other (concurrency)
   issue in which case the would still fail after 30s

Please don't merge this yet, let's trigger rebuild several times to see if the test would still timeout or not.