### PR TITLE
[6.5.x] Fix compilation problems caused by changes in KIE API

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/StatefulProcessSession.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/StatefulProcessSession.java
@@ -405,4 +405,9 @@ public class StatefulProcessSession extends AbstractRuntime implements StatefulK
     public void destroy() {
         dispose();
     }
+
+	@Override
+	public void submit(AtomicAction atomicAction) {
+		throw new UnsupportedOperationException("Drools session operation only");
+	}
 }


### PR DESCRIPTION
After changes in KIE API introduced by DROOLS-1267, it is not possible to compile jBPM as well as KIE Server (and maybe other projects). I have implemented `submit` method added to KIE API by throwing `UnsupportedOperationException`. Not sure if it is the best approach but it seems like it is only Drools-related operation.