### PR TITLE
Use default timeout for jbpm-bpmn2 tests to avoid build hanging

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/JbpmBpmn2TestCase.java
@@ -79,6 +79,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
+import org.junit.rules.Timeout;
 import org.junit.runner.Description;
 import org.kie.api.KieBase;
 import org.kie.api.KieServices;
@@ -141,6 +142,10 @@ public abstract class JbpmBpmn2TestCase extends AbstractBaseTest {
 
     private RequireLocking testReqLocking;
     private RequirePersistence testReqPersistence;
+
+    @Rule
+    public Timeout globalTimeout = Timeout.seconds(30);
+
     @Rule
     public TestRule watcher = new TestWatcher() {
         protected void starting(Description description) {

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/StandaloneBPMNProcessTest.java
@@ -74,13 +74,13 @@ public class StandaloneBPMNProcessTest extends JbpmBpmn2TestCase {
     
     @Parameters
     public static Collection<Object[]> persistence() {
-        Object[][] data = new Object[][] { 
-                { false, false }, 
+        Object[][] data = new Object[][] {
+                { false, false },
                 { true, false }, 
                 { true, true } 
                 };
         return Arrays.asList(data);
-    };
+    }
     
     public StandaloneBPMNProcessTest(boolean persistence, boolean locking) {
         super(persistence, locking);


### PR DESCRIPTION
@mswiderski this does not fix the test, but it at least prevents the build from hanging when the tests goes havoc

Timeout 30s should I think be enough even for slower machines. If we have tests that take more than that, we should probably think about fixing them.