### PR TITLE
[6.5.x] Fix compilation errors after changes in KIE API (DROOLS-1275)

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/process/StatefulProcessSession.java
+++ b/jbpm-flow/src/main/java/org/jbpm/process/StatefulProcessSession.java
@@ -354,6 +354,10 @@ public class StatefulProcessSession extends AbstractRuntime implements StatefulK
 		throw new UnsupportedOperationException();
 	}
 
+	public void update(FactHandle handle, Object object, String... modifiedProperties) {
+		throw new UnsupportedOperationException();
+	}
+
 	public void addEventListener(RuleRuntimeEventListener listener) {
 		// Do nothing
 	}


### PR DESCRIPTION
I have fixed compilation problems caused by [this commit](https://github.com/droolsjbpm/droolsjbpm-knowledge/commit/78002f726ef8dca62a3252597619965e239b3f0e).