### PR TITLE
JBPM-5294: Automatically reassigned tasks remain in task list even af…

### DIFF
--- a/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/preprocessor/PotOwnerTasksPreprocessor.java
+++ b/jbpm-services/jbpm-kie-services/src/main/java/org/jbpm/kie/services/impl/query/preprocessor/PotOwnerTasksPreprocessor.java
@@ -16,8 +16,7 @@
 
 package org.jbpm.kie.services.impl.query.preprocessor;
 
-import static org.dashbuilder.dataset.filter.FilterFactory.OR;
-import static org.dashbuilder.dataset.filter.FilterFactory.equalsTo;
+import static org.dashbuilder.dataset.filter.FilterFactory.*;
 import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_ACTUALOWNER;
 import static org.jbpm.services.api.query.QueryResultMapper.COLUMN_ORGANIZATIONAL_ENTITY;
 
@@ -46,15 +45,18 @@ public class PotOwnerTasksPreprocessor implements DataSetPreprocessor {
         if (identityProvider == null) {
             return;
         }
-        
+
         List<Comparable> orgEntities = new ArrayList<Comparable>(identityProvider.getRoles());
-        orgEntities.add(identityProvider.getName());
 
         List<ColumnFilter> condList = new ArrayList<ColumnFilter>();
-        
-        condList.add(equalsTo(COLUMN_ACTUALOWNER, identityProvider.getName()));
-        condList.add(equalsTo(COLUMN_ORGANIZATIONAL_ENTITY, orgEntities));
-        
+
+        ColumnFilter myGroupFilter;
+        myGroupFilter = AND(
+                equalsTo(COLUMN_ORGANIZATIONAL_ENTITY, orgEntities),
+                OR(equalsTo(COLUMN_ACTUALOWNER, ""), isNull(COLUMN_ACTUALOWNER)));
+
+        condList.add( OR(myGroupFilter, equalsTo(COLUMN_ACTUALOWNER, identityProvider.getName())));
+
         if (lookup.getFirstFilterOp() != null) {
             lookup.getFirstFilterOp().addFilterColumn(OR(condList));
         } else {

--- a/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/query/preprocessor/PotOwnerTasksPreprocessorTest.java
+++ b/jbpm-services/jbpm-kie-services/src/test/java/org/jbpm/kie/services/impl/query/preprocessor/PotOwnerTasksPreprocessorTest.java
@@ -1,0 +1,50 @@
+package org.jbpm.kie.services.impl.query.preprocessor;
+
+import java.util.ArrayList;
+
+import org.dashbuilder.dataset.DataSetLookup;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.internal.identity.IdentityProvider;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PotOwnerTasksPreprocessorTest {
+
+    @Mock
+    public IdentityProvider identityProvider;
+
+
+    public DataSetLookup dataSetLookup;
+
+    @InjectMocks
+    public PotOwnerTasksPreprocessor potOwnerTasksPreprocessor;
+
+    @Test
+    public void testSetUser() {
+        dataSetLookup = new DataSetLookup();
+        String role1="role1";
+        String role2="role2";
+        String userId="userId";
+
+        ArrayList<String> roles = new ArrayList<>();
+        roles.add(role1);
+        roles.add(role2);
+        DataSetLookup dataSetLookup = new DataSetLookup();
+        when(identityProvider.getRoles()).thenReturn(roles);
+        when(identityProvider.getName()).thenReturn(userId);
+
+        potOwnerTasksPreprocessor.preprocess(dataSetLookup);
+
+        assertEquals("(((ID = " + role1 + ", " + role2 + " AND (ACTUALOWNER =  OR ACTUALOWNER is_null )) OR ACTUALOWNER = "+userId+"))",
+                dataSetLookup.getFirstFilterOp().getColumnFilterList().get(0).toString());
+    }
+
+
+}


### PR DESCRIPTION
…ter being reassigned.
Changed the Preprocessor adding conditions to differentiate between the tasks without actual owner but allowed to any user connected role, and the tasks with actualowner set to connected user. 