### PR TITLE
JBPM-5082: Added users management configurations for the jbpm installer.

### DIFF
--- a/jbpm-installer/auth/users.properties
+++ b/jbpm-installer/auth/users.properties
@@ -1,9 +1,18 @@
-admin=admin
-krisv=krisv
-john=john
-mary=mary
-sales-rep=sales-rep
-katy=katy
-jack=jack
-salaboy=salaboy
-kieserver=kieserver1!
+# admin/admin
+admin=207b6e0cc556d7084b5e2db7d822555c
+# krisv/krisv
+krisv=7b21a03b9918f9c629a46e119a9b8714
+# john/john
+john=afda4373c6021f3f5841cd6c0a027244
+# mary/mary
+mary=17c942d820347808fc822ce710b5308f
+# sales-rep/sales-rep
+sales-rep=b79a6ff72056e86c70eaa2922585ef25
+# katy/katy
+katy=fd37b5d0b82ce027bfad677a54fbccee
+# jack/jack
+jack=984ba30e11dda7b9ed86ba7b73d01481
+# salaboy/salaboy
+salaboy=d4af256e7007fea2e581d539e05edd1b
+# kieserver/kieserver1!
+kieserver=16c6511893651c9b4b57e0c027a96075

--- a/jbpm-installer/standalone-eap-6.4.0.xml
+++ b/jbpm-installer/standalone-eap-6.4.0.xml
@@ -39,10 +39,10 @@
             <security-realm name="ApplicationRealm">
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
-                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
-                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
         </security-realms>
@@ -265,9 +265,11 @@
             <security-domains>
                  <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/roles.properties"/>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
                 </security-domain>

--- a/jbpm-installer/standalone-eap-7.0.0.xml
+++ b/jbpm-installer/standalone-eap-7.0.0.xml
@@ -43,10 +43,10 @@
             <security-realm name="ApplicationRealm">
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
-                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
-                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
         </security-realms>
@@ -317,9 +317,11 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/roles.properties"/>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
                 </security-domain>

--- a/jbpm-installer/standalone-full-eap-6.4.0.xml
+++ b/jbpm-installer/standalone-full-eap-6.4.0.xml
@@ -44,10 +44,10 @@
             <security-realm name="ApplicationRealm">
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
-                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
-                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
         </security-realms>
@@ -362,9 +362,11 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/roles.properties"/>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
                 </security-domain>

--- a/jbpm-installer/standalone-full-eap-7.0.0.xml
+++ b/jbpm-installer/standalone-full-eap-7.0.0.xml
@@ -46,10 +46,10 @@
             <security-realm name="ApplicationRealm">
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
-                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
-                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
         </security-realms>
@@ -354,9 +354,11 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/roles.properties"/>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
                 </security-domain>

--- a/jbpm-installer/standalone-full-wildfly-10.0.0.Final.xml
+++ b/jbpm-installer/standalone-full-wildfly-10.0.0.Final.xml
@@ -46,10 +46,10 @@
             <security-realm name="ApplicationRealm">
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
-                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
-                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
         </security-realms>
@@ -354,9 +354,11 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/roles.properties"/>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
                 </security-domain>

--- a/jbpm-installer/standalone-wildfly-10.0.0.Final.xml
+++ b/jbpm-installer/standalone-wildfly-10.0.0.Final.xml
@@ -43,10 +43,10 @@
             <security-realm name="ApplicationRealm">
                 <authentication>
                     <local default-user="$local" allowed-users="*" skip-group-loading="true"/>
-                    <properties path="application-users.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="users.properties" relative-to="jboss.server.config.dir"/>
                 </authentication>
                 <authorization>
-                    <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
+                    <properties path="roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
         </security-realms>
@@ -317,9 +317,11 @@
             <security-domains>
                 <security-domain name="other" cache-type="default">
                     <authentication>
-                        <login-module code="UsersRoles" flag="required">
-                            <module-option name="usersProperties" value="${jboss.server.config.dir}/users.properties"/>
-                            <module-option name="rolesProperties" value="${jboss.server.config.dir}/roles.properties"/>
+                        <login-module code="Remoting" flag="optional">
+                            <module-option name="password-stacking" value="useFirstPass"/>
+                        </login-module>
+                        <login-module code="RealmDirect" flag="required">
+                            <module-option name="password-stacking" value="useFirstPass"/>
                         </login-module>
                     </authentication>
                 </security-domain>


### PR DESCRIPTION
Hi @krisv , @mswiderski , @dgutierr ,

Can you please check if you agree on this change? If so, will create the PR for master as well. 

Currently passwords on the jbpm-installer are on clear text, but both add-user script and our users management stuff do encrypt the passwords. So adding users from the UI adds the hashed password on the properties file, but the default passwords are on clear text.

I see two options:
1- Adding a configuration flag on the users management stuff to indicate wether passwords should be encrypted and use this configuration to set no encryption on the jbpm-installer.
2.- Moving the jbpm-installer to the use of encrypted passwords, as both add-user script and users management stuff expects.

This PR is the fix for option 2 -> Added users management configurations for the jbpm installer and disabled use of UserRoles login module for the other domain security (use of encrypted password using same RealmDirect module).

Note that the UserRoles login module used on the security domain is replaced by the RealmDirect one, which by default expects the encrypted passwords. This way:
- The passwords are encrypted ( added comments in the password file with the clear text )
- The configuration is centralized on just the realm conftiguration ( no need to specify the file paths on the security domain section as well )

I have checked the workbench and the kieserver, both connectivities works fine and now the users created from the UI can log in fine. Not sure if this change could have more implications...

PS: https://issues.jboss.org/browse/JBPM-5082

Thanks!!