### PR TITLE
RHBPMS-4259 - ServiceTaskHandler logs error messages for web service …

### DIFF
--- a/jbpm-workitems/src/main/java/org/jbpm/process/workitem/bpmn2/ServiceTaskHandler.java
+++ b/jbpm-workitems/src/main/java/org/jbpm/process/workitem/bpmn2/ServiceTaskHandler.java
@@ -199,16 +199,16 @@ public class ServiceTaskHandler extends AbstractLogOrThrowWorkItemHandler implem
                     try {
                         client = dcf.createClient(importObj.getLocation(), new QName(importObj.getNamespace(), interfaceRef), getInternalClassLoader(), null);
                         clients.put(interfaceRef, client);
-                        
+                        logger.info("WS Client is created for {" + importObj.getNamespace() + "}" + interfaceRef);
                         return client;
                     } catch (Exception e) {
-                	    logger.error("Error when creating WS Client", e);
+                        logger.info("Error when creating WS Client. You can ignore this error as long as a client is eventually created", e);
                         continue;
                     }
                 }
             }
         }
-        
+
         return null;
 
     }


### PR DESCRIPTION
…namespace/servicename attempts

I chose INFO rather than DEBUG because there could be a case that the log is important. I also added INFO log "WS Client is created for ..." so that users can be sure that the client is eventually created.