### PR TITLE
Skip findbugs for jbpm-installer

### DIFF
--- a/jbpm-installer/pom.xml
+++ b/jbpm-installer/pom.xml
@@ -12,6 +12,10 @@
   <artifactId>jbpm-installer</artifactId>
   <name>jBPM :: Installer</name>
 
+  <properties>
+    <findbugs.skip>true</findbugs.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
 * there are no java classes in src/main/java
   which could be analyzed and the plugin just
   fails becuase of that