### PR TITLE
Fixed Timestamp parameters for LocalTaskAuditTest.testDueDateUpdateSa…

### DIFF
--- a/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/service/TaskAuditBaseTest.java
+++ b/jbpm-human-task/jbpm-human-task-audit/src/test/java/org/jbpm/services/task/audit/service/TaskAuditBaseTest.java
@@ -476,7 +476,8 @@ public abstract class TaskAuditBaseTest extends HumanTaskServicesBaseTest {
 
     @Test
     public void testDueDateUpdateSame() {
-        testDueDateUpdate(getToday(), getToday(), false);
+        final Timestamp today = getToday();
+        testDueDateUpdate(today, today, false);
     }
 
     @Test


### PR DESCRIPTION
Just a quick fix in test - providing same time as arguments of the test method. It called getToday() twice, which can differ in milliseconds sometimes, because it is called twice. 