### PR TITLE
Override xnio versions because of productization kie-platform-bom

### DIFF
--- a/jbpm-container-test/jbpm-container-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-container-test-suite/pom.xml
@@ -669,6 +669,17 @@
             <artifactId>jboss-logging</artifactId>
             <version>3.2.1.Final</version>
           </dependency>
+          <!-- xnio has to be overridden because productization kie-platform-bom uses an older version of it which is incompatible -->
+          <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+            <version>${version.org.jboss.xnio.wildfly10}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-nio</artifactId>
+            <version>${version.org.jboss.xnio.wildfly10}</version>
+          </dependency>
         </dependencies>
       </dependencyManagement>
       <dependencies>


### PR DESCRIPTION
Hi,

I had to override xnio versions because otherwise these tests would not run properly with productized binaries on EAP 7. This change won't probably be needed on master.

Marián
