### PR TITLE
[JBPM-5343] fix JPA annotations to make the entities work with both H…

### DIFF
--- a/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/EmailNotificationImpl.java
+++ b/jbpm-human-task/jbpm-human-task-jpa/src/main/java/org/jbpm/services/task/impl/model/EmailNotificationImpl.java
@@ -32,8 +32,8 @@ import org.kie.internal.task.api.model.EmailNotificationHeader;
 import org.kie.internal.task.api.model.Language;
 import org.kie.internal.task.api.model.NotificationType;
 
-
-@Entity
+@Entity(name = "Notification") // need to use `name = "Notification"` to make the DDL scripts work with both Hibernate 4 and Hibernate 5
+// see https://issues.jboss.org/browse/RHBPMS-4244 for more info
 @DiscriminatorValue("EmailNotification")
 public class EmailNotificationImpl extends NotificationImpl implements org.kie.internal.task.api.model.EmailNotification{
 

--- a/jbpm-installer/pom.xml
+++ b/jbpm-installer/pom.xml
@@ -50,11 +50,7 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.hibernate.javax.persistence</groupId>
-      <artifactId>hibernate-jpa-2.0-api</artifactId>
-      <scope>test</scope>
-    </dependency>
+
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
@@ -141,7 +137,7 @@
         <filtering>true</filtering>
       </testResource>
     </testResources>
-    
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -168,4 +164,168 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- TODO: remove this whole profile once we upgrade to Hibernate 5 (and thus Hibernate 4 will no longer be supported)-->
+      <id>default-hibernate4</id>
+      <activation>
+        <property>
+          <name>!hibernate5</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.hibernate.javax.persistence</groupId>
+          <artifactId>hibernate-jpa-2.0-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+
+    <profile>
+      <!-- Used to run the DDL/Upgrade scripts tests against Hibernate 5 (which is included in WildFly10/EAP7)-->
+      <!-- TODO: remove this whole profile once we upgrade to Hibernate 5 (and thus Hibernate 4 will no longer be supported)-->
+      <id>hibernate5</id>
+      <activation>
+        <property>
+          <name>hibernate5</name>
+        </property>
+      </activation>
+
+      <properties>
+        <version.org.hibernate>5.0.9.Final</version.org.hibernate>
+        <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
+        <!-- Versions compatible with Hibernate 5 -->
+        <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
+        <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
+        <version.com.h2database>1.4.192</version.com.h2database>
+      </properties>
+
+      <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <version>${version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>${version.org.hibernate}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>${version.org.hibernate}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.hibernate.common</groupId>
+            <artifactId>hibernate-commons-annotations</artifactId>
+            <version>${version.org.hibernate.commons.annotations}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${version.com.h2database}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>${version.org.jboss.logging.jboss-logging}</version>
+          </dependency>
+
+          <!-- The old 'hibernate-jpa-2.0-api' dependency needs to be excluded in all artifacts which depend on it directly.
+               Hibernate 5 uses 'hibernate-jpa-2.1-api'.  -->
+          <dependency>
+            <groupId>org.drools</groupId>
+            <artifactId>drools-persistence-jpa</artifactId>
+            <version>${version.org.kie}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-persistence-jpa</artifactId>
+            <version>${version.org.kie}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-persistence-jpa</artifactId>
+            <version>${version.org.kie}</version>
+            <type>test-jar</type>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-audit</artifactId>
+            <version>${version.org.kie}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-kie-services</artifactId>
+            <version>${version.org.kie}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-human-task-core</artifactId>
+            <version>${version.org.kie}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+          <dependency>
+            <groupId>org.jbpm</groupId>
+            <artifactId>jbpm-human-task-jpa</artifactId>
+            <version>${version.org.kie}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>org.hibernate.javax.persistence</groupId>
+                <artifactId>hibernate-jpa-2.0-api</artifactId>
+              </exclusion>
+            </exclusions>
+          </dependency>
+
+        </dependencies>
+      </dependencyManagement>
+
+      <dependencies>
+        <dependency>
+          <groupId>org.hibernate.javax.persistence</groupId>
+          <artifactId>hibernate-jpa-2.1-api</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/jbpm-installer/src/test/filtered-resources/META-INF/persistence.xml
+++ b/jbpm-installer/src/test/filtered-resources/META-INF/persistence.xml
@@ -118,9 +118,82 @@
       <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform"/>
     </properties>
   </persistence-unit>
-  <persistence-unit name="clearSchema" transaction-type="JTA">
+  <persistence-unit name="dbTestingUpdate" transaction-type="JTA">
     <provider>org.hibernate.ejb.HibernatePersistence</provider>
     <jta-data-source>jdbc/testDS3</jta-data-source>
+    <mapping-file>META-INF/JBPMorm.xml</mapping-file>
+
+    <!-- drools-persistence-jpa -->
+    <class>org.drools.persistence.info.SessionInfo</class>
+    <class>org.drools.persistence.info.WorkItemInfo</class>
+    <!-- jbpm-persistence-api -->
+    <class>org.jbpm.persistence.processinstance.ProcessInstanceInfo</class>
+    <!-- Unknown entity.. some deprecated thing? -->
+    <!--<class>org.jbpm.persistence.processinstance.ProcessInstanceEventInfo</class>-->
+    <class>org.jbpm.persistence.correlation.CorrelationKeyInfo</class>
+    <class>org.jbpm.persistence.correlation.CorrelationPropertyInfo</class>
+    <!-- jbpm-runtime-manager -->
+    <class>org.jbpm.runtime.manager.impl.jpa.ContextMappingInfo</class>
+    <!-- jbpm-kie-services -->
+    <class>org.jbpm.kie.services.impl.store.DeploymentStoreEntry</class>
+    <class>org.jbpm.kie.services.impl.query.persistence.QueryDefinitionEntity</class>
+    <!-- jbpm-human-task-jpa -->
+    <class>org.jbpm.services.task.impl.model.AttachmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.BooleanExpressionImpl</class>
+    <class>org.jbpm.services.task.impl.model.CommentImpl</class>
+    <!-- Unknown entity.. some deprecated thing? -->
+    <!--<class>org.jbpm.services.task.impl.model.CompletionBehaviorImpl</class>-->
+    <class>org.jbpm.services.task.impl.model.ContentImpl</class>
+    <class>org.jbpm.services.task.impl.model.DeadlineImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationHeaderImpl</class>
+    <class>org.jbpm.services.task.impl.model.EmailNotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.EscalationImpl</class>
+    <class>org.jbpm.services.task.impl.model.GroupImpl</class>
+    <class>org.jbpm.services.task.impl.model.I18NTextImpl</class>
+    <class>org.jbpm.services.task.impl.model.NotificationImpl</class>
+    <class>org.jbpm.services.task.impl.model.OrganizationalEntityImpl</class>
+    <!-- Unknown entity.. some deprecated thing? -->
+    <!--<class>org.jbpm.services.task.impl.model.\</class>-->
+    <class>org.jbpm.services.task.impl.model.ReassignmentImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskDefImpl</class>
+    <class>org.jbpm.services.task.impl.model.TaskImpl</class>
+    <class>org.jbpm.services.task.impl.model.UserImpl</class>
+    <!-- jbpm-human-task-audit -->
+    <class>org.jbpm.services.task.audit.impl.model.AuditTaskImpl</class>
+    <class>org.jbpm.services.task.audit.impl.model.BAMTaskSummaryImpl</class>
+    <class>org.jbpm.services.task.audit.impl.model.TaskEventImpl</class>
+    <class>org.jbpm.services.task.audit.impl.model.TaskVariableImpl</class>
+    <!-- jbpm-executor -->
+    <class>org.jbpm.executor.entities.ErrorInfo</class>
+    <class>org.jbpm.executor.entities.RequestInfo</class>
+    <!-- jbpm-audit -->
+    <class>org.jbpm.process.audit.NodeInstanceLog</class>
+    <class>org.jbpm.process.audit.ProcessInstanceLog</class>
+    <class>org.jbpm.process.audit.VariableInstanceLog</class>
+    <exclude-unlisted-classes>true</exclude-unlisted-classes>
+    <properties>
+      <property name="hibernate.max_fetch_depth" value="3"/>
+      <property name="hibernate.hbm2ddl.auto" value="update"/>
+      <property name="hibernate.show_sql" value="false"/>
+
+      <property name="hibernate.dialect" value="${maven.hibernate.dialect}"/>
+
+      <property name="hibernate.connection.driver_class" value="${maven.jdbc.driver.class}"/>
+      <property name="hibernate.connection.url" value="${maven.jdbc.url}"/>
+      <property name="hibernate.connection.username" value="${maven.jdbc.username}"/>
+      <property name="hibernate.connection.password" value="${maven.jdbc.password}"/>
+      <property name="hibernate.default_schema" value="${maven.jdbc.schema}"/>
+
+      <!-- BZ 841786: AS7/EAP 6/Hib 4 uses new (sequence) generators which seem to cause problems -->
+      <property name="hibernate.id.new_generator_mappings" value="false"/>
+
+      <!-- The following line is what's used in Hibernate 4 instead of a TransactionManagerLookup class -->
+      <property name="hibernate.transaction.jta.platform" value="org.hibernate.service.jta.platform.internal.BitronixJtaPlatform"/>
+    </properties>
+  </persistence-unit>
+  <persistence-unit name="clearSchema" transaction-type="JTA">
+    <provider>org.hibernate.ejb.HibernatePersistence</provider>
+    <jta-data-source>jdbc/testDS4</jta-data-source>
     <mapping-file>META-INF/JBPMorm.xml</mapping-file>
     <!-- drools-persistence-jpa -->
     <class>org.drools.persistence.info.SessionInfo</class>

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/DDLScriptsTest.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/DDLScriptsTest.java
@@ -1,44 +1,82 @@
 package org.jbpm.persistence.scripts;
 
-import java.io.File;
-import java.io.IOException;
-import java.sql.SQLException;
-
 import org.jbpm.persistence.scripts.util.TestsUtil;
 import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
 
 /**
  * Contains tests that test DDL scripts.
  */
 public class DDLScriptsTest {
+    private static final Logger logger = LoggerFactory.getLogger(DDLScriptsTest.class);
+
+    @BeforeClass
+    public static void printHibernateVersion() {
+        logger.info("Running with Hibernate " + org.hibernate.Version.getVersionString());
+    }
+
+    @Before
+    public void clearSchema() {
+        TestsUtil.clearSchema();
+    }
 
     private static final String DB_DDL_SCRIPTS_RESOURCE_PATH = "/db/ddl-scripts";
 
     /**
      * Tests that DB schema is created properly using DDL scripts.
-     * @throws IOException
      */
     @Test
-    public void testCreateSchema() throws IOException, SQLException {
-        // Clear schema.
-        TestsUtil.clearSchema();
-
-        final TestPersistenceContext scriptRunnerContext = new TestPersistenceContext();
-        scriptRunnerContext.init(PersistenceUnit.SCRIPT_RUNNER);
+    public void createSchemaUsingDDLs() throws Exception {
+        final TestPersistenceContext scriptRunnerContext = createAndInitPersistenceContext(PersistenceUnit.SCRIPT_RUNNER);
         try {
             scriptRunnerContext.executeScripts(new File(getClass().getResource(DB_DDL_SCRIPTS_RESOURCE_PATH).getFile()));
         } finally {
             scriptRunnerContext.clean();
         }
 
-        final TestPersistenceContext dbTestingContext = new TestPersistenceContext();
-        dbTestingContext.init(PersistenceUnit.DB_TESTING);
+        final TestPersistenceContext dbTestingContext = createAndInitPersistenceContext(PersistenceUnit.DB_TESTING_VALIDATE);
         try {
             dbTestingContext.startAndPersistSomeProcess("minimalProcess");
             Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 1);
         } finally {
             dbTestingContext.clean();
         }
+    }
+
+    /**
+     * Simulates the default config for kie-server/kie-wb when deploying the apps for the first time (and without running the DDL scripts first)
+     */
+    @Test
+    public void runHibernateUpdateOnEmptyDB() throws Exception {
+        final TestPersistenceContext dbTestingContext = createAndInitPersistenceContext(PersistenceUnit.DB_TESTING_UPDATE);
+        dbTestingContext.clean();
+    }
+
+    /**
+     * Simulates the case when user executes DDL scripts before deploying the kie-server/kie-wb and leaves the hibernate
+     * config untouched (thus using the default 'update')
+     */
+    @Test
+    public void createSchemaWithDDLsAndRunHibernateUpdate() throws Exception {
+        final TestPersistenceContext scriptRunnerContext = createAndInitPersistenceContext(PersistenceUnit.SCRIPT_RUNNER);
+        try {
+            scriptRunnerContext.executeScripts(new File(getClass().getResource("/db/ddl-scripts").getFile()));
+        } finally {
+            scriptRunnerContext.clean();
+        }
+        final TestPersistenceContext dbTestingContext = createAndInitPersistenceContext(PersistenceUnit.DB_TESTING_UPDATE);
+        dbTestingContext.clean();
+    }
+
+    private TestPersistenceContext createAndInitPersistenceContext(PersistenceUnit persistenceUnit) {
+        TestPersistenceContext testPersistenceContext = new TestPersistenceContext();
+        testPersistenceContext.init(persistenceUnit);
+        return testPersistenceContext;
     }
 }

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/PersistenceUnit.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/PersistenceUnit.java
@@ -10,14 +10,19 @@ public enum PersistenceUnit {
     SCRIPT_RUNNER("scriptRunner", "jdbc/testDS1"),
 
     /**
-     * Persistence unit used for test cases validation.
+     * Persistence unit used for test cases validation. Uses Hibernate's 'validate'.
      */
-    DB_TESTING("dbTesting", "jdbc/testDS2"),
+    DB_TESTING_VALIDATE("dbTesting", "jdbc/testDS2"),
+
+    /**
+     * Persistence unit used for test cases validation. Uses 'Hibernate's update' instead of 'validate'
+     */
+    DB_TESTING_UPDATE("dbTestingUpdate", "jdbc/testDS3"),
 
     /**
      * Persistence unit used for clearing the database schema.
      */
-    CLEAR_SCHEMA("clearSchema", "jdbc/testDS3");
+    CLEAR_SCHEMA("clearSchema", "jdbc/testDS4");
 
     /**
      * Name of persistence unit. Must correspond to persistence unit names in persistence.xml.

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/UpgradeScriptsTest.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/UpgradeScriptsTest.java
@@ -47,7 +47,7 @@ public class UpgradeScriptsTest {
         }
 
         final TestPersistenceContext dbTestingContext = new TestPersistenceContext();
-        dbTestingContext.init(PersistenceUnit.DB_TESTING);
+        dbTestingContext.init(PersistenceUnit.DB_TESTING_VALIDATE);
         try {
             dbTestingContext.startAndPersistSomeProcess(TEST_PROCESS_ID);
             Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 1);
@@ -87,7 +87,7 @@ public class UpgradeScriptsTest {
         }
 
         final TestPersistenceContext dbTestingContext = new TestPersistenceContext();
-        dbTestingContext.init(PersistenceUnit.DB_TESTING);
+        dbTestingContext.init(PersistenceUnit.DB_TESTING_VALIDATE);
         try {
             Assert.assertTrue(dbTestingContext.getStoredProcessesCount() == 1);
             Assert.assertTrue(dbTestingContext.getStoredSessionsCount() == 1);

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/SQLScriptUtil.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/SQLScriptUtil.java
@@ -37,7 +37,7 @@ public final class SQLScriptUtil {
         final StringBuilder command = new StringBuilder();
         for (String line : scriptLines) {
             // Ignore comments.
-            if (line.startsWith("--") || line.startsWith("#")) {
+            if (line.trim().startsWith("--") || line.trim().startsWith("#")) {
                 continue;
             }
             // If the whole line is a delimiter -> add buffered command to found commands.

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
     <maven.jdbc.driver.jar/>
     <maven.jdbc.username>sa</maven.jdbc.username>
     <maven.jdbc.password>sasa</maven.jdbc.password>
-    <maven.jdbc.url>jdbc:h2:tcp://localhost/target/jbpm-test;MVCC=TRUE</maven.jdbc.url>
+    <maven.jdbc.url>jdbc:h2:tcp://localhost/${project.basedir}/target/jbpm-test;MVCC=TRUE</maven.jdbc.url>
     <maven.jdbc.schema>public</maven.jdbc.schema>
   </properties>
 


### PR DESCRIPTION
…ibernate 4 and Hibernate 5

 * there is a new profile for jbpm-installer called 'hibernate5' which
   makes it very easy to run the tests with Hibernate 5 (instead of
   the default Hibernat 4) - 'mvn clean install -Dhibernate5'
 * the change in EmailNotificationImpl should be fully backwards
   compatible as the entity name still stays the same, but is now
   explicitly set, intead of relying on hibernate to deduce the
   name from the class name

Forward-port of #616 