### PR TITLE
JBPM-4646: fix case definition sorting

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/CaseRuntimeDataServiceImpl.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/CaseRuntimeDataServiceImpl.java
@@ -210,10 +210,10 @@ public class CaseRuntimeDataServiceImpl implements CaseRuntimeDataService, Deplo
     @Override
     public Collection<CaseDefinition> getCases(QueryContext queryContext) {
         Collection<CaseDefinition> cases = availableCases.stream()
-                .skip(queryContext.getOffset())
                 .filter(caseDef -> caseDef.isActive())
+                .sorted(new CaseDefinitionComparator(queryContext.getOrderBy(), queryContext.isAscending()))
+                .skip(queryContext.getOffset())
                 .limit(queryContext.getCount())
-                .sorted(new CaseDefinitionComparator(queryContext.getOrderBy()))
                 .collect(toList());
         return cases;
     }
@@ -223,11 +223,11 @@ public class CaseRuntimeDataServiceImpl implements CaseRuntimeDataService, Deplo
         String pattern = "(?i)^.*"+filter+".*$";
         
         Collection<CaseDefinition> cases = availableCases.stream()
-                .skip(queryContext.getOffset())
                 .filter(caseDef -> caseDef.isActive() 
                         && (caseDef.getId().matches(pattern) || caseDef.getName().matches(pattern)))
+                .sorted(new CaseDefinitionComparator(queryContext.getOrderBy(), queryContext.isAscending()))
+                .skip(queryContext.getOffset())
                 .limit(queryContext.getCount())
-                .sorted(new CaseDefinitionComparator(queryContext.getOrderBy()))
                 .collect(toList());
         return cases;
     }
@@ -235,10 +235,10 @@ public class CaseRuntimeDataServiceImpl implements CaseRuntimeDataService, Deplo
     @Override
     public Collection<CaseDefinition> getCasesByDeployment(String deploymentId, QueryContext queryContext) {
         Collection<CaseDefinition> cases = availableCases.stream()
-                .skip(queryContext.getOffset())
                 .filter(caseDef -> caseDef.isActive() && caseDef.getDeploymentId().equals(deploymentId))
+                .sorted(new CaseDefinitionComparator(queryContext.getOrderBy(), queryContext.isAscending()))
+                .skip(queryContext.getOffset())
                 .limit(queryContext.getCount())
-                .sorted(new CaseDefinitionComparator(queryContext.getOrderBy()))
                 .collect(toList());
         return cases;
     }

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/model/CaseDefinitionComparator.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/model/CaseDefinitionComparator.java
@@ -29,20 +29,33 @@ import java.util.Comparator;
 public class CaseDefinitionComparator implements Comparator<CaseDefinitionImpl> {
     
     private String orderBy;
+    private boolean ascending;
     
-    public CaseDefinitionComparator(String orderBy) {   
+    public CaseDefinitionComparator(String orderBy, Boolean ascending) {
         this.orderBy = orderBy;
+        this.ascending = ascending == null ? Boolean.TRUE : ascending;
     }
 
     @Override
     public int compare(CaseDefinitionImpl o1, CaseDefinitionImpl o2) {
+        int result = 0;
+
         if ("CaseName".equals(orderBy)) {
-            return o1.getName().compareTo(o2.getName());
+            result = o1.getName().compareTo(o2.getName());
         } else if ("CaseId".equals(orderBy)) {
-            return o1.getId().compareTo(o2.getId());
+            result = o1.getId().compareTo(o2.getId());
         } else if ("Project".equals(orderBy)) {
-            return o1.getDeploymentId().compareTo(o2.getDeploymentId());
+            result = o1.getDeploymentId().compareTo(o2.getDeploymentId());
         }
-        return 0;
+
+        if (!ascending) {
+            result = reverseCompareResult(result);
+        }
+
+        return result;
+    }
+
+    private int reverseCompareResult(int compareResult) {
+        return -compareResult;
     }
 }


### PR DESCRIPTION
Placed case definition sorting before paging - results have to be sorted first to provide correct input for paging.
Introduced ascending/descending switch.
Removed redundant whitespaces from test.