### PR TITLE
[6.5.x] Remove unused property for Maven resolver

### DIFF
--- a/jbpm-container-test/jbpm-container-test-suite/src/main/java/org/jbpm/test/container/tools/IntegrationMavenResolver.java
+++ b/jbpm-container-test/jbpm-container-test-suite/src/main/java/org/jbpm/test/container/tools/IntegrationMavenResolver.java
@@ -29,8 +29,8 @@ public class IntegrationMavenResolver {
         File pom = new File(localRepositoryPath, "org/jbpm/shrinkwrap-war-profiles/" + version
                 + "/shrinkwrap-war-profiles-" + version + ".pom");
 
-        final MavenResolverSystem resolver = Boolean.getBoolean(System.getProperty("MAVEN_USE_LOCAL_REPO", "false"))
-                ? Maven.configureResolver().fromFile("settings.xml") : Maven.resolver();
+        // Custom settings.xml can be passed via org.apache.maven.user-settings property
+        final MavenResolverSystem resolver = Maven.resolver();
 
         return resolver.loadPomFromFile(pom, profiles);
     }


### PR DESCRIPTION
Hi,

I have noticed, that one property in container tests is not used anymore, so I got rid of it.

Thanks
