### PR TITLE
[6.5.x] RHBPMS-4370 - Remote EJB client freezes due to locking of PPI runtime…

### DIFF
--- a/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/PerProcessInstanceRuntimeManager.java
+++ b/jbpm-runtime-manager/src/main/java/org/jbpm/runtime/manager/impl/PerProcessInstanceRuntimeManager.java
@@ -563,6 +563,7 @@ public class PerProcessInstanceRuntimeManager extends AbstractRuntimeManager {
     	@Override
     	public TaskService initTaskService(Context<?> context, InternalRuntimeManager manager, RuntimeEngine engine) {
     		InternalTaskService internalTaskService = (InternalTaskService) taskServiceFactory.newTaskService();
+    		registerDisposeCallback(engine, new DisposeSessionTransactionSynchronization(manager, engine));
             configureRuntimeOnTaskService(internalTaskService, engine);
     		return internalTaskService;
     	}


### PR DESCRIPTION
… manager on server side.

(cherry picked from commit 25e09210917b3fb9bdbd414bdb713cea51f9915f)

@rsynek would it be possible to give it a try with tests that you have ran when you found the problem?