### PR TITLE
[6.4.x] Backports for  6.3.4

### DIFF
--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/ProcessHandler.java
@@ -69,6 +69,7 @@ import org.jbpm.workflow.core.node.EndNode;
 import org.jbpm.workflow.core.node.EventNode;
 import org.jbpm.workflow.core.node.EventSubProcessNode;
 import org.jbpm.workflow.core.node.EventTrigger;
+import org.jbpm.workflow.core.node.FaultNode;
 import org.jbpm.workflow.core.node.HumanTaskNode;
 import org.jbpm.workflow.core.node.RuleSetNode;
 import org.jbpm.workflow.core.node.Split;
@@ -747,6 +748,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
     }
 
     private void postProcessNodes(RuleFlowProcess process, NodeContainer container) {
+        List<String> eventSubProcessHandlers = new ArrayList<String>();
         for (Node node: container.getNodes()) {
             
             if (node instanceof StateNode) {
@@ -804,7 +806,9 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                                             exceptionHandler.setAction(action);
                                             exceptionHandler.setFaultVariable(faultVariable);
                                             if (faultCode != null) {
-                                            	exceptionScope.setExceptionHandler(type.replaceFirst(replaceRegExp, ""), exceptionHandler);
+                                                String trimmedType = type.replaceFirst(replaceRegExp, "");
+                                                exceptionScope.setExceptionHandler(trimmedType, exceptionHandler);
+                                                eventSubProcessHandlers.add(trimmedType);
                                             } else {
                                             	exceptionScope.setExceptionHandler(faultCode, exceptionHandler);
                                             }
@@ -838,7 +842,7 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
 
                                 if (constraintTrigger.getConstraint() != null) {
                                     String processId = ((RuleFlowProcess) container).getId();
-                                    String type = "RuleFlowStateEventSubProcess-" + processId + "-" + eventSubProcessNode.getUniqueId();
+                                    String type = "RuleFlowStateEventSubProcess-Event-" + processId + "-" + eventSubProcessNode.getUniqueId();
                                     EventTypeFilter eventTypeFilter = new EventTypeFilter();
                                     eventTypeFilter.setType(type);
                                     eventSubProcessNode.addEvent(eventTypeFilter);
@@ -858,6 +862,16 @@ public class ProcessHandler extends BaseAbstractHandler implements Handler {
                 	throw new IllegalArgumentException("Event node '" + node.getName() + "' [" + node.getId() + "] has no incoming connection");
                 }
             }  
+        }
+        
+     // process fault node to disable termnate parent if there is event subprocess handler
+        for (Node node: container.getNodes()) {
+            if (node instanceof FaultNode) {
+                FaultNode faultNode = (FaultNode) node;
+                if (eventSubProcessHandlers.contains(faultNode.getFaultName())) {
+                    faultNode.setTerminateParent(false);
+                }
+            }
         }
     }
 

--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/IntermediateEventTest.java
@@ -66,6 +66,7 @@ import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
 import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.ObjectFilter;
+import org.kie.api.runtime.process.NodeInstance;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.process.WorkItem;
 import org.kie.api.runtime.process.WorkItemManager;
@@ -82,8 +83,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
     @Parameters
     public static Collection<Object[]> persistence() {
-        Object[][] data = new Object[][] { 
-                { false, false }, 
+        Object[][] data = new Object[][] {
+                { false, false },
                 { true, false },
                 { true, true }
                 };
@@ -94,11 +95,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             .getLogger(IntermediateEventTest.class);
 
     private KieSession ksession;
-    
+
     public IntermediateEventTest(boolean persistence, boolean locking) {
         super(persistence, locking);
     }
-    
+
     @BeforeClass
     public static void setup() throws Exception {
         setUpDataSource();
@@ -187,7 +188,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
-    
+
     @Test
     public void testSignalBoundaryEventOnTaskWithSignalName() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-BoundarySignalWithNameEventOnTaskbpmn2.bpmn");
@@ -441,7 +442,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 new SystemOutWorkItemHandler());
         ksession.signalEvent("Yes", "YesValue", processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
-        
+
         ksession = restoreSession(ksession, true);
         ksession.addEventListener(countDownListener);
         ksession.getWorkItemManager().registerWorkItemHandler("Email1",
@@ -458,9 +459,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // Timer
         processInstance = ksession.startProcess("com.sample.test");
         assertProcessInstanceActive(processInstance);
-        
+
         countDownListener.waitTillCompleted();
-        
+
         ksession = restoreSession(ksession, true);
         ksession.addEventListener(countDownListener);
         ksession.getWorkItemManager().registerWorkItemHandler("Email1",
@@ -502,7 +503,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession.getWorkItemManager().registerWorkItemHandler("Email2",
                 new SystemOutWorkItemHandler());
         ksession.insert(jack);
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -581,7 +582,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         receiveTaskHandler.messageReceived("YesMessage", "YesValue");
 
     }
-    
+
     @Test
     public void testEventBasedSplitWithSubprocess() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-ExclusiveEventBasedGatewayInSubprocess.bpmn2");
@@ -591,7 +592,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession.startProcess("com.sample.bpmn.testEBGInSubprocess");
         assertProcessInstanceActive(processInstance);
         ksession = restoreSession(ksession, true);
-        
+
         ksession.signalEvent("StopSignal", "", processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
 
@@ -600,28 +601,28 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         processInstance = ksession.startProcess("com.sample.bpmn.testEBGInSubprocess");
         assertProcessInstanceActive(processInstance);
         ksession = restoreSession(ksession, true);
-        
+
         ksession.signalEvent("ContinueSignal", "", processInstance.getId());
-        
+
         assertProcessInstanceActive(processInstance);
         ksession = restoreSession(ksession, true);
-        
+
         ksession.signalEvent("StopSignal", "", processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
     }
 
     @Test
     public void testEventSubprocessSignal() throws Exception {
-        String [] nodes = { 
+        String [] nodes = {
                 "start", "User Task 1",
                 "end", "Sub Process 1", "start-sub", "sub-script", "end-sub"
         };
         runTestEventSubprocessSignal("BPMN2-EventSubprocessSignal.bpmn2", nodes);
     }
-    
+
     @Test
     public void testEventSubprocessSignalNested() throws Exception {
-        String [] nodes = { 
+        String [] nodes = {
                 "Start",
                 "Sub Process",
                 "Sub Start",
@@ -638,8 +639,8 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         };
         runTestEventSubprocessSignal("BPMN2-EventSubprocessSignal-Nested.bpmn2", nodes);
     }
-    
-    public void runTestEventSubprocessSignal(String processFile, String [] completedNodes) throws Exception { 
+
+    public void runTestEventSubprocessSignal(String processFile, String [] completedNodes) throws Exception {
         KieBase kbase = createKnowledgeBase(processFile);
         final List<Long> executednodes = new ArrayList<Long>();
         ProcessEventListener listener = new DefaultProcessEventListener() {
@@ -828,9 +829,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testEventSubprocessTimer() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("Script Task 1", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessTimer.bpmn2");
-        
+
         ksession = createKnowledgeSession(kbase);
         ksession.addEventListener(countDownListener);
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
@@ -854,7 +855,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @RequirePersistence
     public void testEventSubprocessTimerCycle() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("Script Task 1", 4);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessTimerCycle.bpmn2");
 
         ksession = createKnowledgeSession(kbase);
@@ -902,7 +903,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Person person = new Person();
         person.setName("john");
         ksession.insert(person);
-        
+
 
         WorkItem workItem = workItemHandler.getWorkItem();
         assertNotNull(workItem);
@@ -913,11 +914,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertEquals(1, executednodes.size());
 
     }
-    
+
     @Test(timeout=10000)
     public void testEventSubprocessMessageWithLocalVars() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
-        
+
         KieBase kbase = createKnowledgeBase("subprocess/BPMN2-EventSubProcessWithLocalVariables.bpmn2");
         final Set<String> variablevalues = new HashSet<String>();
         ProcessEventListener listener = new DefaultProcessEventListener() {
@@ -937,14 +938,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession.addEventListener(countDownListener);
         ProcessInstance processInstance = ksession.startProcess("EventSPWithVars");
         assertProcessInstanceActive(processInstance);
-        
+
         Map<String, String> data = new HashMap<String, String>();
         ksession.signalEvent("Message-MAIL", data, processInstance.getId());
         countDownListener.waitTillCompleted();
-        
+
         processInstance = ksession.getProcessInstance(processInstance.getId());
-        assertNull(processInstance);   
-        
+        assertNull(processInstance);
+
         assertEquals(2, variablevalues.size());
         assertTrue(variablevalues.contains("SCRIPT1"));
         assertTrue(variablevalues.contains("SCRIPT2"));
@@ -963,7 +964,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceCompleted(processInstance);
 
     }
-    
+
     @Test
     public void testMessageIntermediateThrowVerifyWorkItemData() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventMessage.bpmn2");
@@ -974,20 +975,20 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         params.put("x", "MyValue");
         ProcessInstance processInstance = ksession.startProcess("MessageIntermediateEvent", params);
         assertProcessInstanceCompleted(processInstance);
-        
+
         WorkItem workItem = handler.getWorkItem();
         assertNotNull(workItem);
         assertTrue(workItem instanceof org.drools.core.process.instance.WorkItem);
-        
+
         long nodeInstanceId = ((org.drools.core.process.instance.WorkItem) workItem).getNodeInstanceId();
         long nodeId = ((org.drools.core.process.instance.WorkItem) workItem).getNodeId();
-        
+
         assertNotNull(nodeId);
         assertTrue(nodeId > 0);
         assertNotNull(nodeInstanceId);
         assertTrue(nodeInstanceId > 0);
     }
-    
+
     @Test
     public void testMessageIntermediateThrowVerifyWorkItemDataDeploymentId() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventMessage.bpmn2");
@@ -998,35 +999,35 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         params.put("x", "MyValue");
         ProcessInstance processInstance = ksession.startProcess("MessageIntermediateEvent", params);
         assertProcessInstanceCompleted(processInstance);
-        
+
         WorkItem workItem = handler.getWorkItem();
         assertNotNull(workItem);
         assertTrue(workItem instanceof org.drools.core.process.instance.WorkItem);
-        
+
         long nodeInstanceId = ((org.drools.core.process.instance.WorkItem) workItem).getNodeInstanceId();
         long nodeId = ((org.drools.core.process.instance.WorkItem) workItem).getNodeId();
         String deploymentId = ((org.drools.core.process.instance.WorkItem) workItem).getDeploymentId();
-        
+
         assertNotNull(nodeId);
         assertTrue(nodeId > 0);
         assertNotNull(nodeInstanceId);
         assertTrue(nodeInstanceId > 0);
         assertNull(deploymentId);
-        
+
         // now set deployment id as part of ksession's env
         ksession.getEnvironment().set("deploymentId", "testDeploymentId");
-        
+
         ksession.startProcess("MessageIntermediateEvent", params);
         assertProcessInstanceCompleted(processInstance);
-        
+
         workItem = handler.getWorkItem();
         assertNotNull(workItem);
         assertTrue(workItem instanceof org.drools.core.process.instance.WorkItem);
-        
+
         nodeInstanceId = ((org.drools.core.process.instance.WorkItem) workItem).getNodeInstanceId();
         nodeId = ((org.drools.core.process.instance.WorkItem) workItem).getNodeId();
         deploymentId = ((org.drools.core.process.instance.WorkItem) workItem).getDeploymentId();
-        
+
         assertNotNull(nodeId);
         assertTrue(nodeId > 0);
         assertNotNull(nodeInstanceId);
@@ -1094,7 +1095,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        ProcessInstance processInstance = ksession.startProcess("TimerBoundaryEvent");        
+        ProcessInstance processInstance = ksession.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
         ksession = restoreSession(ksession, true);
@@ -1105,7 +1106,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testTimerBoundaryEventDateISO() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("TimerEvent", 1);
-        
+
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-TimerBoundaryEventDateISO.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.addEventListener(countDownListener);
@@ -1125,7 +1126,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testTimerBoundaryEventCycle1() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("TimerEvent", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventCycle1.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
@@ -1141,7 +1142,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testTimerBoundaryEventCycle2() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("TimerEvent", 3);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventCycle2.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
@@ -1169,7 +1170,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         ksession.abortProcessInstance(processInstance.getId());
     }
-    
+
     @Test(timeout=10000)
     @RequirePersistence
     public void testTimerBoundaryEventCycleISOWithPersistence() throws Exception {
@@ -1180,7 +1181,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
 
         ksession.addEventListener(countDownListener);
-        
+
         long sessionId = ksession.getIdentifier();
         Environment env = ksession.getEnvironment();
         ksession.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
@@ -1191,11 +1192,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         logger.info("dispose");
         ksession.dispose();
-        
+
         ksession = JPAKnowledgeService.loadStatefulKnowledgeSession(sessionId,
                 kbase, null, env);
         ksession.addEventListener(countDownListener);
-        
+
         assertProcessInstanceActive(processInstance);
         ksession.abortProcessInstance(processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
@@ -1204,18 +1205,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testTimerBoundaryEventInterrupting() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("TimerEvent", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterrupting.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("MyTask", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
         ProcessInstance processInstance = ksession.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
-        
+
         countDownListener.waitTillCompleted();
         ksession = restoreSession(ksession, true);
         logger.debug("Firing timer");
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -1223,22 +1224,22 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testTimerBoundaryEventInterruptingOnTask() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("TimerEvent", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterruptingOnTask.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",  new TestWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         ProcessInstance processInstance = ksession.startProcess("TimerBoundaryEvent");
         assertProcessInstanceActive(processInstance);
         countDownListener.waitTillCompleted();
         ksession = restoreSession(ksession, true);
         logger.debug("Firing timer");
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
-    
+
     @Test
     public void testTimerBoundaryEventInterruptingOnTaskCancelTimer() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-TimerBoundaryEventInterruptingOnTaskCancelTimer.bpmn2");
@@ -1246,22 +1247,22 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler handler = new TestWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         ProcessInstance processInstance = ksession.startProcess("TimerBoundaryEvent");
-        assertProcessInstanceActive(processInstance);  
+        assertProcessInstanceActive(processInstance);
         Collection<TimerInstance> timers = getTimerManager(ksession).getTimers();
         assertEquals(1, timers.size());
-        
+
         ksession = restoreSession(ksession, true);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         timers = getTimerManager(ksession).getTimers();
         assertEquals(1, timers.size());
         ksession.getWorkItemManager().completeWorkItem(handler.getWorkItem().getId(), null);
-        
+
         ksession = restoreSession(ksession, true);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         timers = getTimerManager(ksession).getTimers();
         assertEquals(0, timers.size());
         ksession.getWorkItemManager().completeWorkItem(handler.getWorkItem().getId(), null);
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -1303,7 +1304,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerDuration() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerDuration.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
@@ -1311,14 +1312,14 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ProcessInstance processInstance = ksession
                 .startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        
+
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
-        
+
         ksession = restoreSession(ksession, true);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -1326,12 +1327,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerDateISO() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
-        
+
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventTimerDateISO.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         HashMap<String, Object> params = new HashMap<String, Object>();
         DateTime now = new DateTime(System.currentTimeMillis());
         now.plus(2000);
@@ -1340,7 +1341,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -1348,12 +1349,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerDurationISO() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerDurationISO.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
         // now wait for 1.5 second for timer to trigger
@@ -1361,7 +1362,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession = restoreSession(ksession, true);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
                 new DoNothingWorkItemHandler());
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -1369,20 +1370,20 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerCycle1() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycle1.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
-        
+
         ksession = restoreSession(ksession, true);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
@@ -1390,12 +1391,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerCycleISO() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 5);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleISO.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
 
@@ -1408,19 +1409,19 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerCycle2() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 3);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycle2.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
-        
+
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
         assertProcessInstanceActive(processInstance);
         ksession.abortProcessInstance(processInstance.getId());
-        
+
     }
 
     @Test
@@ -1489,7 +1490,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
     public void testIntermediateCatchEventTimerCycleWithError()
             throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 3);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleWithError.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
@@ -1510,19 +1511,19 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
-    
+
     @Test(timeout=10000)
     @RequirePersistence
     public void testIntermediateCatchEventTimerCycleWithErrorWithPersistence() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 2);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleWithError.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
         ksession.addEventListener(countDownListener);
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
-        
+
 
         final long piId = processInstance.getId();
         ksession.execute(new GenericCommand<Void>() {
@@ -1534,18 +1535,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 return null;
             }
         });
-        
+
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
         assertProcessInstanceActive(processInstance);
-        
+
         Integer xValue = ksession.execute(new GenericCommand<Integer>() {
 
             public Integer execute(Context context) {
                 StatefulKnowledgeSession ksession = (StatefulKnowledgeSession) ((KnowledgeCommandContext) context).getKieSession();
                 WorkflowProcessInstance processInstance = (WorkflowProcessInstance) ksession.getProcessInstance(piId);
                 return (Integer) processInstance.getVariable("x");
-                
+
             }
         });
         assertEquals(new Integer(2), xValue);
@@ -1595,7 +1596,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Person person = new Person();
         person.setName("john");
         ksession.insert(person);
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
         assertNodeTriggered(processInstance.getId(), "StartProcess",
                 "User Task", "Boundary event", "Condition met", "End2");
@@ -1639,7 +1640,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Person person = new Person();
         person.setName("john");
         ksession.insert(person);
-        
+
 
         assertProcessInstanceCompleted(processInstance);
         assertNodeTriggered(processInstance.getId(), "StartProcess",
@@ -1661,7 +1662,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Person person = new Person();
         person.setName("john");
         ksession.insert(person);
-        
+
 
         assertProcessInstanceFinished(processInstance, ksession);
         assertNodeTriggered(processInstance.getId(), "StartProcess", "Hello",
@@ -1686,20 +1687,20 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         ProcessInstance processInstance = ksession.startProcess("jbpm.testing.signal");
         assertProcessInstanceActive(processInstance);
-        
+
         ksession.signalEvent("continue", null, processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
-        
+
         ksession.dispose();
-        
+
         ksession = createKnowledgeSession(kbase);
 
         processInstance = ksession.startProcess("jbpm.testing.signal");
         assertProcessInstanceActive(processInstance);
-        
+
         ksession.signalEvent("forward", null);
         assertProcessInstanceFinished(processInstance, ksession);
-        
+
         ksession.dispose();
     }
 
@@ -1709,12 +1710,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
-        
+
         KieBase kbase2 = createKnowledgeBase("BPMN2-IntermediateCatchEventSignal2.bpmn2");
         KieSession ksession2 = createKnowledgeSession(kbase2);
         ksession2.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
-        ProcessInstance processInstance2 = ksession2.startProcess("IntermediateCatchEvent2");        
-        
+        ProcessInstance processInstance2 = ksession2.startProcess("IntermediateCatchEvent2");
+
         assertProcessInstanceActive(processInstance);
         assertProcessInstanceActive(processInstance2);
         ksession = restoreSession(ksession, true);
@@ -1729,7 +1730,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance2, ksession2);
         ksession2.dispose();
     }
-    
+
     @Test
     @RequirePersistence
     public void testEventTypesLifeCycle() throws Exception {
@@ -1754,12 +1755,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 return processInstancesToSignalList.size();
             }
         });
-        
+
         // Process instance is not waiting for signal
         assertEquals(0, signalListSize);
 
         ksession.getWorkItemManager().completeWorkItem(1, null);
-        
+
         signalListSize = ksession.execute(new GenericCommand<Integer>() {
             public Integer execute(Context context) {
                 SingleSessionCommandService commandService = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) ksession)
@@ -1773,12 +1774,12 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 return processInstancesToSignalList.size();
             }
         });
-        
+
         // Process instance is waiting for signal now
         assertEquals(1, signalListSize);
 
         ksession.signalEvent("MySignal", null);
-        
+
         signalListSize = ksession.execute(new GenericCommand<Integer>() {
             public Integer execute(Context context) {
                 SingleSessionCommandService commandService = (SingleSessionCommandService) ((CommandBasedStatefulKnowledgeSession) ksession)
@@ -1792,16 +1793,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
                 return processInstancesToSignalList.size();
             }
         });
-        
+
         // Process instance is not waiting for signal
         assertEquals(0, signalListSize);
-        
+
         ksession.getWorkItemManager().completeWorkItem(2, null);
 
         ksession.dispose();
         separateEmf.close();
     }
-    
+
     @Test
     public void testIntermediateCatchEventNoIncommingConnection() throws Exception {
         try {
@@ -1811,9 +1812,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         	assertNotNull(e.getMessage());
         	assertTrue(e.getMessage().contains("has no incoming connection"));
         }
-        
+
     }
-    
+
     @Test
     public void testSignalBoundaryEventOnMultiInstanceSubprocess() throws Exception {
         KieBase kbase = createKnowledgeBase(
@@ -1821,27 +1822,27 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
         TestWorkItemHandler handler = new TestWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        
+
         Map<String, Object> params = new HashMap<String, Object>();
         List<String> approvers = new ArrayList<String>();
         approvers.add("john");
         approvers.add("john");
-        
+
         params.put("approvers", approvers);
 
         ProcessInstance processInstance = ksession.startProcess("boundary-catch-error-event", params);
         assertProcessInstanceActive(processInstance);
-        
+
         List<WorkItem> workItems = handler.getWorkItems();
-        assertNotNull(workItems);                
+        assertNotNull(workItems);
         assertEquals(2, workItems.size());
-        
+
         ksession.signalEvent("Outside", null, processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
-        
-        ksession.dispose();        
+
+        ksession.dispose();
     }
-    
+
     @Test
     public void testSignalBoundaryEventNoInteruptOnMultiInstanceSubprocess() throws Exception {
         KieBase kbase = createKnowledgeBase(
@@ -1849,33 +1850,33 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
         TestWorkItemHandler handler = new TestWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        
+
         Map<String, Object> params = new HashMap<String, Object>();
         List<String> approvers = new ArrayList<String>();
         approvers.add("john");
         approvers.add("john");
-        
+
         params.put("approvers", approvers);
 
         ProcessInstance processInstance = ksession.startProcess("boundary-catch-error-event", params);
         assertProcessInstanceActive(processInstance);
-        
+
         List<WorkItem> workItems = handler.getWorkItems();
-        assertNotNull(workItems);                
+        assertNotNull(workItems);
         assertEquals(2, workItems.size());
-        
+
         ksession.signalEvent("Outside", null, processInstance.getId());
-        
+
         assertProcessInstanceActive(processInstance.getId(), ksession);
-        
+
         for (WorkItem wi : workItems) {
         	ksession.getWorkItemManager().completeWorkItem(wi.getId(), null);
         }
         assertProcessInstanceFinished(processInstance, ksession);
-        
-        ksession.dispose();        
+
+        ksession.dispose();
     }
-    
+
     @Test
     public void testErrorBoundaryEventOnMultiInstanceSubprocess() throws Exception {
         KieBase kbase = createKnowledgeBase(
@@ -1883,27 +1884,27 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         StatefulKnowledgeSession ksession = createKnowledgeSession(kbase);
         TestWorkItemHandler handler = new TestWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
-        
+
         Map<String, Object> params = new HashMap<String, Object>();
         List<String> approvers = new ArrayList<String>();
         approvers.add("john");
         approvers.add("john");
-        
+
         params.put("approvers", approvers);
 
         ProcessInstance processInstance = ksession.startProcess("boundary-catch-error-event", params);
         assertProcessInstanceActive(processInstance);
-        
+
         List<WorkItem> workItems = handler.getWorkItems();
-        assertNotNull(workItems);                
+        assertNotNull(workItems);
         assertEquals(2, workItems.size());
-        
+
         ksession.signalEvent("Inside", null, processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
-        
-        ksession.dispose();        
+
+        ksession.dispose();
     }
-    
+
     @Test
     public void testIntermediateCatchEventSignalAndBoundarySignalEvent() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-BoundaryEventWithSignals.bpmn2");
@@ -1917,16 +1918,16 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         // now signal process instance
         ksession.signalEvent("moveon", "", processInstance.getId());
         assertProcessInstanceActive(processInstance);
-        
+
         WorkItem wi = handler.getWorkItem();
         assertNotNull(wi);
-        
+
         // signal boundary event on user task
         ksession.signalEvent("moveon", "", processInstance.getId());
-        
-        assertProcessInstanceFinished(processInstance, ksession);        
+
+        assertProcessInstanceFinished(processInstance, ksession);
     }
-    
+
     @Test
     public void testSignalIntermediateThrowEventWithTransformation() throws Exception {
         KieBase kbase = createKnowledgeBaseWithoutDumper(
@@ -1936,7 +1937,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler handler = new TestWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
-        
+
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "john");
         ProcessInstance processInstance = ksession.startProcess("BoundarySignalOnTask");
@@ -1945,11 +1946,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance2, ksession);
 
         assertProcessInstanceFinished(processInstance, ksession);
-        
+
         String var = getProcessVarValue(processInstance, "x");
         assertEquals("JOHN", var);
     }
-    
+
     @Test
     public void testSignalBoundaryEventWithTransformation() throws Exception {
         KieBase kbase = createKnowledgeBaseWithoutDumper(
@@ -1959,7 +1960,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         TestWorkItemHandler handler = new TestWorkItemHandler();
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task",
                 handler);
-        
+
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "john");
         ProcessInstance processInstance = ksession.startProcess("BoundarySignalOnTask");
@@ -1968,11 +1969,11 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance2, ksession);
 
         assertProcessInstanceFinished(processInstance, ksession);
-        
+
         String var = getProcessVarValue(processInstance, "x");
         assertEquals("JOHN", var);
     }
-    
+
     @Test
     public void testMessageIntermediateThrowWithTransformation() throws Exception {
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateThrowEventMessageWithTransformation.bpmn2");
@@ -1987,7 +1988,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 						messageContent.append(workItem.getParameter("Message"));
 						super.executeWorkItem(workItem, manager);
 					}
-        	
+
         });
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "MyValue");
@@ -1998,7 +1999,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertEquals("MYVALUE", messageContent.toString());
 
     }
-    
+
     @Test
     public void testIntermediateCatchEventSignalWithTransformation() throws Exception {
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventSignalWithTransformation.bpmn2");
@@ -2033,10 +2034,10 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertNotNull(var);
         assertEquals("SOMEVALUE", var);
     }
-    
+
     @Test
     public void testEventSubprocessSignalWithTransformation() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-EventSubprocessSignalWithTransformation.bpmn2");    
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-EventSubprocessSignalWithTransformation.bpmn2");
         ksession = createKnowledgeSession(kbase);
 
         TestWorkItemHandler workItemHandler = new TestWorkItemHandler();
@@ -2058,22 +2059,22 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertEquals("JOHN", var);
 
     }
-    
+
     @Test
     public void testMultipleMessageSignalSubprocess() throws Exception {
-        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultipleMessageSignalSubprocess.bpmn2");    
+        KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-MultipleMessageSignalSubprocess.bpmn2");
         ksession = createKnowledgeSession(kbase);
-        
+
         ProcessInstance processInstance = ksession.startProcess("com.sample.bpmn.Multiple_MessageSignal_Subprocess");
 		System.out.println("Parent Process ID: " + processInstance.getId());
-		
+
 		ksession.signalEvent("Message-Message_1","Test",processInstance.getId());
 		assertProcessInstanceActive(processInstance.getId(), ksession);
-		
+
 		ksession.signalEvent("Message-Message_1","Test",processInstance.getId());
 		assertProcessInstanceCompleted(processInstance.getId(), ksession);
     }
-    
+
     @Test
     public void testIntermediateCatchEventSignalWithRef() throws Exception {
         KieBase kbase = createKnowledgeBaseWithoutDumper("BPMN2-IntermediateCatchEventSignalWithRef.bpmn2");
@@ -2088,7 +2089,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertNodeTriggered(processInstance.getId(), "StartProcess", "UserTask", "EndProcess", "event");
 
     }
-    
+
     @Test(timeout=10000)
     public void testTimerMultipleInstances() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 3);
@@ -2097,41 +2098,41 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ksession.addEventListener(countDownListener);
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        
+
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         ProcessInstance processInstance = ksession.startProcess("boundaryTimerMultipleInstances");
         assertProcessInstanceActive(processInstance);
 
         countDownListener.waitTillCompleted();
-        
+
         List<WorkItem> workItems = handler.getWorkItems();
         assertNotNull(workItems);
         assertEquals(3, workItems.size());
-        
+
         for (WorkItem wi : workItems) {
             ksession.getWorkItemManager().completeWorkItem(wi.getId(), null);
         }
-        
+
         assertProcessInstanceFinished(processInstance, ksession);
     }
-    
+
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerCycleCron() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 3);
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerCycleCron.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.addEventListener(countDownListener);
-        
+
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent");
         assertProcessInstanceActive(processInstance);
 
         countDownListener.waitTillCompleted();
-        assertProcessInstanceActive(processInstance);        
-        
-        ksession.abortProcessInstance(processInstance.getId());        
+        assertProcessInstanceActive(processInstance);
+
+        ksession.abortProcessInstance(processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
     }
-    
+
     @Test(timeout=10000)
     public void testIntermediateCatchEventTimerDurationValueFromGlobal() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
@@ -2139,9 +2140,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ksession.addEventListener(countDownListener);
         ksession.setGlobal("time", "2s");
-        
+
         ProcessInstance processInstance = ksession.startProcess("interruptedTimer");
-        
+
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger
         countDownListener.waitTillCompleted();
@@ -2149,7 +2150,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
-    
+
     @Test(timeout=10000)
     public void testTimerBoundaryEventCronCycle() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("Send Update Timer", 3);
@@ -2176,7 +2177,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         assertProcessInstanceFinished(processInstance, ksession);
     }
-    
+
     @Test(timeout=10000)
     public void testIntermediateTimerParallelGateway() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("Timer1", 1);
@@ -2189,18 +2190,18 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession.addEventListener(countDownListener2);
         ksession.addEventListener(countDownListener3);
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        
+
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         ProcessInstance processInstance = ksession.startProcess("Evaluation.timer-parallel");
         assertProcessInstanceActive(processInstance);
 
         countDownListener.waitTillCompleted();
-        countDownListener2.waitTillCompleted(); 
-        countDownListener3.waitTillCompleted(); 
+        countDownListener2.waitTillCompleted();
+        countDownListener3.waitTillCompleted();
         assertProcessInstanceCompleted(processInstance.getId(), ksession);
-        
+
     }
-    
+
     @Test(timeout=10000)
     public void testIntermediateTimerEventMI() throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("After timer", 3);
@@ -2209,148 +2210,148 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         ksession = createKnowledgeSession(kbase);
         ksession.addEventListener(countDownListener);
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        
+
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         ProcessInstance processInstance = ksession.startProcess("defaultprocessid");
         assertProcessInstanceActive(processInstance);
 
         countDownListener.waitTillCompleted();
         assertProcessInstanceActive(processInstance.getId(), ksession);
-        
+
         ksession.abortProcessInstance(processInstance.getId());
-        
+
         assertProcessInstanceAborted(processInstance.getId(), ksession);
     }
-    
+
     @Test
     public void testThrowIntermediateSignalWithScope() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2IntermediateThrowEventScope.bpmn2");
         ksession = createKnowledgeSession(kbase);
-        
+
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        
+
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         Map<String, Object> params = new HashMap<String, Object>();
-        
+
         ProcessInstance processInstance = ksession.startProcess("intermediate-event-scope", params);
         ProcessInstance processInstance2 = ksession.startProcess("intermediate-event-scope", params);
-        
+
         assertProcessInstanceActive(processInstance);
         assertProcessInstanceActive(processInstance2);
-        
+
         assertNodeActive(processInstance.getId(), ksession, "Complete work", "Wait");
         assertNodeActive(processInstance2.getId(), ksession, "Complete work", "Wait");
-        
+
         List<WorkItem> items = handler.getWorkItems();
-        
+
         WorkItem wi = items.get(0);
 
         Map<String, Object> result = new HashMap<String, Object>();
         result.put("_output", "sending event");
-        
+
         ksession.getWorkItemManager().completeWorkItem(wi.getId(), result);
-        
+
         assertProcessInstanceCompleted(processInstance);
         assertProcessInstanceActive(processInstance2);
         assertNodeActive(processInstance2.getId(), ksession, "Complete work", "Wait");
-        
+
         wi = items.get(1);
         ksession.getWorkItemManager().completeWorkItem(wi.getId(), result);
         assertProcessInstanceCompleted(processInstance2);
 
     }
-    
+
     @Test
     public void testThrowEndSignalWithScope() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2EndThrowEventScope.bpmn2");
         ksession = createKnowledgeSession(kbase);
-        
+
         TestWorkItemHandler handler = new TestWorkItemHandler();
-        
+
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         Map<String, Object> params = new HashMap<String, Object>();
-        
+
         ProcessInstance processInstance = ksession.startProcess("end-event-scope", params);
         ProcessInstance processInstance2 = ksession.startProcess("end-event-scope", params);
-        
+
         assertProcessInstanceActive(processInstance);
         assertProcessInstanceActive(processInstance2);
-        
+
         assertNodeActive(processInstance.getId(), ksession, "Complete work", "Wait");
         assertNodeActive(processInstance2.getId(), ksession, "Complete work", "Wait");
-        
+
         List<WorkItem> items = handler.getWorkItems();
-        
+
         WorkItem wi = items.get(0);
 
         Map<String, Object> result = new HashMap<String, Object>();
         result.put("_output", "sending event");
-        
+
         ksession.getWorkItemManager().completeWorkItem(wi.getId(), result);
-        
+
         assertProcessInstanceCompleted(processInstance);
         assertProcessInstanceActive(processInstance2);
         assertNodeActive(processInstance2.getId(), ksession, "Complete work", "Wait");
-        
+
         wi = items.get(1);
         ksession.getWorkItemManager().completeWorkItem(wi.getId(), result);
         assertProcessInstanceCompleted(processInstance2);
 
     }
-    
-    
-    
+
+
+
     @Test
     public void testThrowIntermediateSignalWithExternalScope() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventExternalScope.bpmn2");
         ksession = createKnowledgeSession(kbase);
-        
+
         TestWorkItemHandler handler = new TestWorkItemHandler();
         WorkItemHandler externalHandler = new WorkItemHandler() {
-            
+
             @Override
             public void executeWorkItem(WorkItem workItem, WorkItemManager manager) {
                 String signal = (String) workItem.getParameter("Signal");
                 ksession.signalEvent(signal, null);
-                
+
                 manager.completeWorkItem(workItem.getId(), null);
-                
+
             }
-            
+
             @Override
-            public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {                
+            public void abortWorkItem(WorkItem workItem, WorkItemManager manager) {
             }
         };
-        
+
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", handler);
         ksession.getWorkItemManager().registerWorkItemHandler("External Send Task", externalHandler);
         Map<String, Object> params = new HashMap<String, Object>();
-        
+
         ProcessInstance processInstance = ksession.startProcess("intermediate-event-scope", params);
-                
+
         assertProcessInstanceActive(processInstance);
-        
+
         assertNodeActive(processInstance.getId(), ksession, "Complete work", "Wait");
-        
+
         List<WorkItem> items = handler.getWorkItems();
         assertEquals(1, items.size());
         WorkItem wi = items.get(0);
 
         Map<String, Object> result = new HashMap<String, Object>();
         result.put("_output", "sending event");
-        
+
         ksession.getWorkItemManager().completeWorkItem(wi.getId(), result);
 
         assertProcessInstanceCompleted(processInstance);
 
     }
-    
+
     @Test
     public void testIntermediateCatchEventSignalWithVariable() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventSignalWithVariable.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new SystemOutWorkItemHandler());
-        
+
         String signalVar = "myVarSignal";
         Map<String, Object> parameters = new HashMap<String, Object>();
         parameters.put("signalName", signalVar);
@@ -2363,7 +2364,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertNodeTriggered(processInstance.getId(), "StartProcess", "UserTask", "EndProcess", "event");
 
     }
-    
+
     @Test
     public void testSignalIntermediateThrowWithVariable() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateThrowEventSignalWithVariable.bpmn2", "BPMN2-IntermediateCatchEventSignalWithVariable.bpmn2");
@@ -2375,20 +2376,20 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         parameters.put("signalName", signalVar);
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent", parameters);
         assertProcessInstanceActive(processInstance);
-        
-        ksession = restoreSession(ksession, true);        
-        
+
+        ksession = restoreSession(ksession, true);
+
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", "MyValue");
         params.put("signalName", signalVar);
         ProcessInstance processInstanceThrow = ksession.startProcess("SignalIntermediateEvent", params);
         assertEquals(ProcessInstance.STATE_COMPLETED, processInstanceThrow.getState());
-        
+
         // catch process instance should now be completed
         assertProcessInstanceFinished(processInstance, ksession);
 
     }
-    
+
     @Test
     public void testInvalidDateTimerBoundary() throws Exception {
         try {
@@ -2398,7 +2399,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             assertTrue(e.getMessage().contains("Could not parse date 'abcdef'"));
         }
     }
-    
+
     @Test
     public void testInvalidDurationTimerBoundary() throws Exception {
         try {
@@ -2408,7 +2409,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             assertTrue(e.getMessage().contains("Could not parse delay 'abcdef'"));
         }
     }
-    
+
     @Test
     public void testInvalidCycleTimerBoundary() throws Exception {
         try {
@@ -2418,7 +2419,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
             assertTrue(e.getMessage().contains("Could not parse delay 'abcdef'"));
         }
     }
-    
+
     @Test
     public void testIntermediateCatchEventConditionSetVariableAfter() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventConditionSetVariableAfter.bpmn2");
@@ -2429,9 +2430,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         ksession = restoreSession(ksession, true);
         ksession.addEventListener(new RuleAwareProcessEventLister());
-        
+
         Collection<? extends Object> processInstances = ksession.getObjects(new ObjectFilter() {
-            
+
             @Override
             public boolean accept(Object object) {
                 if (object instanceof ProcessInstance) {
@@ -2442,15 +2443,15 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         });
         assertNotNull(processInstances);
         assertEquals(1, processInstances.size());
-        
+
         // now activate condition
         Person person = new Person();
         person.setName("Jack");
         ksession.insert(person);
         assertProcessInstanceFinished(processInstance, ksession);
-        
+
         processInstances = ksession.getObjects(new ObjectFilter() {
-            
+
             @Override
             public boolean accept(Object object) {
                 if (object instanceof ProcessInstance) {
@@ -2462,7 +2463,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertNotNull(processInstances);
         assertEquals(0, processInstances.size());
     }
-    
+
     @Test
     public void testIntermediateCatchEventConditionRemovePIAfter() throws Exception {
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventCondition.bpmn2");
@@ -2473,9 +2474,9 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         ksession = restoreSession(ksession, true);
         ksession.addEventListener(new RuleAwareProcessEventLister());
-        
+
         Collection<? extends Object> processInstances = ksession.getObjects(new ObjectFilter() {
-            
+
             @Override
             public boolean accept(Object object) {
                 if (object instanceof ProcessInstance) {
@@ -2486,7 +2487,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         });
         assertNotNull(processInstances);
         assertEquals(1, processInstances.size());
-        
+
         // now activate condition
         Person person = new Person();
         person.setName("Jack");
@@ -2494,7 +2495,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertProcessInstanceFinished(processInstance, ksession);
 
         processInstances = ksession.getObjects(new ObjectFilter() {
-            
+
             @Override
             public boolean accept(Object object) {
                 if (object instanceof ProcessInstance) {
@@ -2506,13 +2507,13 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         assertNotNull(processInstances);
         assertEquals(0, processInstances.size());
     }
-    
+
     @Test(timeout=10000)
     @RequirePersistence
     public void testIntermediateCatchEventTimerDurationWithError()
             throws Exception {
         CountDownProcessEventListener countDownListener = new CountDownProcessEventListener("timer", 1);
-        
+
         KieBase kbase = createKnowledgeBase("BPMN2-IntermediateCatchEventTimerDurationWithError.bpmn2");
         ksession = createKnowledgeSession(kbase);
         ksession.getWorkItemManager().registerWorkItemHandler("Human Task", new DoNothingWorkItemHandler());
@@ -2520,7 +2521,7 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("x", 0);
         ProcessInstance processInstance = ksession.startProcess("IntermediateCatchEvent", params);
-        
+
         long waitTime = 2;
         assertProcessInstanceActive(processInstance);
         // now wait for 1 second for timer to trigger
@@ -2531,12 +2532,38 @@ public class IntermediateEventTest extends JbpmBpmn2TestCase {
 
         // reschedule it to allow to move on
         ksession.setGlobal("TestOK", Boolean.TRUE);
-     
+
         ksession.execute(new UpdateTimerCommand(processInstance.getId(), "timer", waitTime + 1));
         countDownListener.reset(1);
         countDownListener.waitTillCompleted();
-                
+
         assertProcessInstanceFinished(processInstance, ksession);
 
+    }
+
+    @Test
+    public void testEventSubprocessWithEmbeddedSignals() throws Exception {
+        KieBase kbase = createKnowledgeBase("BPMN2-EventSubprocessErrorSignalEmbedded.bpmn2");
+        ksession = createKnowledgeSession(kbase);
+
+        ProcessInstance processInstance = ksession.startProcess("project2.myerrorprocess");
+
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+        assertProcessInstanceActive(processInstance);
+        ksession = restoreSession(ksession, true);
+
+        ksession.signalEvent("signal1", null, processInstance.getId());
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+
+        for (NodeInstance nodeInstance: ((WorkflowProcessInstance) processInstance).getNodeInstances()) {
+            System.out.println("Active node instance " + nodeInstance);
+        }
+
+        ksession.signalEvent("signal2", null, processInstance.getId());
+        assertProcessInstanceActive(processInstance.getId(), ksession);
+
+        ksession.signalEvent("signal3", null, processInstance.getId());
+
+        assertProcessInstanceFinished(processInstance, ksession);
     }
 }

--- a/jbpm-bpmn2/src/test/resources/BPMN2-EventSubprocessErrorSignalEmbedded.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/BPMN2-EventSubprocessErrorSignalEmbedded.bpmn2
@@ -1,0 +1,323 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_pgP6sHTaEeaoApuNXeI-uQ" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:signal id="signal1" name="signal1"/>
+  <bpmn2:signal id="signal2" name="signal2"/>
+  <bpmn2:signal id="signal3" name="signal3"/>
+  <bpmn2:error id="myerrorref" errorCode="myerrorref"/>
+  <bpmn2:process id="project2.myerrorprocess" drools:packageName="org.jbpm" drools:version="1.0" name="myerrorprocess" isExecutable="true">
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_39010054-5D46-4E8C-A9FA-64E46B4E293A</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:scriptTask id="_C17A804A-5140-4FF4-9F27-3608B2F8D4A3" drools:selectable="true" name="Parent Process" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_39010054-5D46-4E8C-A9FA-64E46B4E293A</bpmn2:incoming>
+      <bpmn2:outgoing>_FCC2871C-1D99-46E5-BE85-294F2F5EC58A</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Parent process run...");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_39010054-5D46-4E8C-A9FA-64E46B4E293A" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_C17A804A-5140-4FF4-9F27-3608B2F8D4A3"/>
+    <bpmn2:intermediateCatchEvent id="_A55CA959-D4DA-403D-8F0B-2078F58D2DDE" drools:bgcolor="#f5deb3" drools:selectable="true" drools:bordercolor="#a0522d" drools:boundaryca="" name="Signal1">
+      <bpmn2:incoming>_FCC2871C-1D99-46E5-BE85-294F2F5EC58A</bpmn2:incoming>
+      <bpmn2:outgoing>_05EE3913-3EAD-424B-92DC-6465CFA11A50</bpmn2:outgoing>
+      <bpmn2:signalEventDefinition id="_pgP6sXTaEeaoApuNXeI-uQ" signalRef="signal1"/>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:sequenceFlow id="_FCC2871C-1D99-46E5-BE85-294F2F5EC58A" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_C17A804A-5140-4FF4-9F27-3608B2F8D4A3" targetRef="_A55CA959-D4DA-403D-8F0B-2078F58D2DDE"/>
+    <bpmn2:endEvent id="_D5BCD39D-61A8-49BA-8AC1-477D27500F0D" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_05EE3913-3EAD-424B-92DC-6465CFA11A50</bpmn2:incoming>
+      <bpmn2:errorEventDefinition id="_pgP6snTaEeaoApuNXeI-uQ" drools:erefname="myerrorref" errorRef="myerrorref"/>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_05EE3913-3EAD-424B-92DC-6465CFA11A50" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_A55CA959-D4DA-403D-8F0B-2078F58D2DDE" targetRef="_D5BCD39D-61A8-49BA-8AC1-477D27500F0D"/>
+    <bpmn2:subProcess id="_AB7869E8-1143-43A1-8F62-EB0FEE4E131D" drools:bgcolor="#ffffff" drools:selectable="true" name="" triggeredByEvent="true">
+      <bpmn2:startEvent id="_41A836D9-83C2-4B6B-A2CB-FB392E62C6EA" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+        <bpmn2:outgoing>_87AD2D24-CFFC-4352-BC76-DA18AE611768</bpmn2:outgoing>
+        <bpmn2:errorEventDefinition id="_pgP6s3TaEeaoApuNXeI-uQ" drools:erefname="myerrorref" errorRef="myerrorref"/>
+      </bpmn2:startEvent>
+      <bpmn2:scriptTask id="_9C6C7F2A-9459-40DE-9675-DDA5CB1A0CD6" drools:selectable="true" name="Script1" scriptFormat="http://www.java.com/java">
+        <bpmn2:incoming>_87AD2D24-CFFC-4352-BC76-DA18AE611768</bpmn2:incoming>
+        <bpmn2:outgoing>_4099F2E8-745B-4C8A-81F5-177D8B3D09A3</bpmn2:outgoing>
+        <bpmn2:script><![CDATA[System.out.println("Script1 run...");]]></bpmn2:script>
+      </bpmn2:scriptTask>
+      <bpmn2:intermediateCatchEvent id="_9BE0054F-3EA1-415D-80F5-3DB0770FA1C0" drools:bgcolor="#f5deb3" drools:selectable="true" drools:bordercolor="#a0522d" drools:boundaryca="" name="Sub-signal1">
+        <bpmn2:incoming>_4099F2E8-745B-4C8A-81F5-177D8B3D09A3</bpmn2:incoming>
+        <bpmn2:outgoing>_C970DF27-4230-4477-9D81-0C34636CE8BB</bpmn2:outgoing>
+        <bpmn2:signalEventDefinition id="_pgP6tHTaEeaoApuNXeI-uQ" signalRef="signal2"/>
+      </bpmn2:intermediateCatchEvent>
+      <bpmn2:scriptTask id="_87B4E535-4BA2-4F83-9F9A-CD147B67C6DE" drools:selectable="true" name="Script2" scriptFormat="http://www.java.com/java">
+        <bpmn2:incoming>_C970DF27-4230-4477-9D81-0C34636CE8BB</bpmn2:incoming>
+        <bpmn2:outgoing>_52E875AC-A9EA-41CF-A168-3C02CEB2AA06</bpmn2:outgoing>
+        <bpmn2:script><![CDATA[System.out.println("Script2 run...");]]></bpmn2:script>
+      </bpmn2:scriptTask>
+      <bpmn2:intermediateCatchEvent id="_EAB2BE48-6748-4C2E-91E1-D27C080E96FA" drools:bgcolor="#f5deb3" drools:selectable="true" drools:bordercolor="#a0522d" drools:boundaryca="" name="Sub-signal2">
+        <bpmn2:incoming>_52E875AC-A9EA-41CF-A168-3C02CEB2AA06</bpmn2:incoming>
+        <bpmn2:outgoing>_AA209FC7-33F3-483C-ABAB-541246AD4445</bpmn2:outgoing>
+        <bpmn2:signalEventDefinition id="_pgP6tXTaEeaoApuNXeI-uQ" signalRef="signal3"/>
+      </bpmn2:intermediateCatchEvent>
+      <bpmn2:endEvent id="_BCAF7A70-3871-44F5-9E24-1A87D436FF93" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+        <bpmn2:incoming>_AA209FC7-33F3-483C-ABAB-541246AD4445</bpmn2:incoming>
+      </bpmn2:endEvent>
+      <bpmn2:sequenceFlow id="_87AD2D24-CFFC-4352-BC76-DA18AE611768" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_41A836D9-83C2-4B6B-A2CB-FB392E62C6EA" targetRef="_9C6C7F2A-9459-40DE-9675-DDA5CB1A0CD6"/>
+      <bpmn2:sequenceFlow id="_4099F2E8-745B-4C8A-81F5-177D8B3D09A3" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_9C6C7F2A-9459-40DE-9675-DDA5CB1A0CD6" targetRef="_9BE0054F-3EA1-415D-80F5-3DB0770FA1C0"/>
+      <bpmn2:sequenceFlow id="_C970DF27-4230-4477-9D81-0C34636CE8BB" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_9BE0054F-3EA1-415D-80F5-3DB0770FA1C0" targetRef="_87B4E535-4BA2-4F83-9F9A-CD147B67C6DE"/>
+      <bpmn2:sequenceFlow id="_52E875AC-A9EA-41CF-A168-3C02CEB2AA06" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_87B4E535-4BA2-4F83-9F9A-CD147B67C6DE" targetRef="_EAB2BE48-6748-4C2E-91E1-D27C080E96FA"/>
+      <bpmn2:sequenceFlow id="_AA209FC7-33F3-483C-ABAB-541246AD4445" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_EAB2BE48-6748-4C2E-91E1-D27C080E96FA" targetRef="_BCAF7A70-3871-44F5-9E24-1A87D436FF93"/>
+    </bpmn2:subProcess>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_pgP6tnTaEeaoApuNXeI-uQ">
+    <bpmndi:BPMNPlane id="_pgP6t3TaEeaoApuNXeI-uQ" bpmnElement="project2.myerrorprocess">
+      <bpmndi:BPMNShape id="_pgP6uHTaEeaoApuNXeI-uQ" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgP6uXTaEeaoApuNXeI-uQ" bpmnElement="_C17A804A-5140-4FF4-9F27-3608B2F8D4A3">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_pgP6unTaEeaoApuNXeI-uQ" bpmnElement="_39010054-5D46-4E8C-A9FA-64E46B4E293A">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_pgP6u3TaEeaoApuNXeI-uQ" bpmnElement="_A55CA959-D4DA-403D-8F0B-2078F58D2DDE">
+        <dc:Bounds height="30.0" width="30.0" x="339.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_pgP6vHTaEeaoApuNXeI-uQ" bpmnElement="_FCC2871C-1D99-46E5-BE85-294F2F5EC58A">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="354.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_pgP6vXTaEeaoApuNXeI-uQ" bpmnElement="_D5BCD39D-61A8-49BA-8AC1-477D27500F0D">
+        <dc:Bounds height="28.0" width="28.0" x="431.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_pgQhwHTaEeaoApuNXeI-uQ" bpmnElement="_05EE3913-3EAD-424B-92DC-6465CFA11A50">
+        <di:waypoint xsi:type="dc:Point" x="354.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="445.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_pgQhwXTaEeaoApuNXeI-uQ" bpmnElement="_AB7869E8-1143-43A1-8F62-EB0FEE4E131D">
+        <dc:Bounds height="169.0" width="595.0" x="75.0" y="255.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgQhwnTaEeaoApuNXeI-uQ" bpmnElement="_41A836D9-83C2-4B6B-A2CB-FB392E62C6EA">
+        <dc:Bounds height="30.0" width="30.0" x="90.0" y="321.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgQhw3TaEeaoApuNXeI-uQ" bpmnElement="_9C6C7F2A-9459-40DE-9675-DDA5CB1A0CD6">
+        <dc:Bounds height="80.0" width="100.0" x="165.0" y="296.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgQhxHTaEeaoApuNXeI-uQ" bpmnElement="_9BE0054F-3EA1-415D-80F5-3DB0770FA1C0">
+        <dc:Bounds height="30.0" width="30.0" x="315.0" y="321.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgQhxXTaEeaoApuNXeI-uQ" bpmnElement="_87B4E535-4BA2-4F83-9F9A-CD147B67C6DE">
+        <dc:Bounds height="80.0" width="100.0" x="395.0" y="296.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgQhxnTaEeaoApuNXeI-uQ" bpmnElement="_EAB2BE48-6748-4C2E-91E1-D27C080E96FA">
+        <dc:Bounds height="30.0" width="30.0" x="525.0" y="321.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_pgQhx3TaEeaoApuNXeI-uQ" bpmnElement="_BCAF7A70-3871-44F5-9E24-1A87D436FF93">
+        <dc:Bounds height="28.0" width="28.0" x="600.0" y="323.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_pgQhyHTaEeaoApuNXeI-uQ" bpmnElement="_87AD2D24-CFFC-4352-BC76-DA18AE611768">
+        <di:waypoint xsi:type="dc:Point" x="30.0" y="81.0"/>
+        <di:waypoint xsi:type="dc:Point" x="140.0" y="81.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_pgQhyXTaEeaoApuNXeI-uQ" bpmnElement="_4099F2E8-745B-4C8A-81F5-177D8B3D09A3">
+        <di:waypoint xsi:type="dc:Point" x="140.0" y="81.0"/>
+        <di:waypoint xsi:type="dc:Point" x="255.0" y="81.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_pgQhynTaEeaoApuNXeI-uQ" bpmnElement="_C970DF27-4230-4477-9D81-0C34636CE8BB">
+        <di:waypoint xsi:type="dc:Point" x="255.0" y="81.0"/>
+        <di:waypoint xsi:type="dc:Point" x="370.0" y="81.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_pgQhy3TaEeaoApuNXeI-uQ" bpmnElement="_52E875AC-A9EA-41CF-A168-3C02CEB2AA06">
+        <di:waypoint xsi:type="dc:Point" x="370.0" y="81.0"/>
+        <di:waypoint xsi:type="dc:Point" x="465.0" y="81.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_pgQhzHTaEeaoApuNXeI-uQ" bpmnElement="_AA209FC7-33F3-483C-ABAB-541246AD4445">
+        <di:waypoint xsi:type="dc:Point" x="465.0" y="81.0"/>
+        <di:waypoint xsi:type="dc:Point" x="577.0" y="336.0"/>
+        <di:waypoint xsi:type="dc:Point" x="577.0" y="337.0"/>
+        <di:waypoint xsi:type="dc:Point" x="539.0" y="82.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_pgQhzXTaEeaoApuNXeI-uQ" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_39010054-5D46-4E8C-A9FA-64E46B4E293A" id="_pgQhznTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AA209FC7-33F3-483C-ABAB-541246AD4445" id="_pgQhz3TaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_87AD2D24-CFFC-4352-BC76-DA18AE611768" id="_pgQh0HTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_4099F2E8-745B-4C8A-81F5-177D8B3D09A3" id="_pgQh0XTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_FCC2871C-1D99-46E5-BE85-294F2F5EC58A" id="_pgQh0nTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_87B4E535-4BA2-4F83-9F9A-CD147B67C6DE" id="_pgQh03TaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_52E875AC-A9EA-41CF-A168-3C02CEB2AA06" id="_pgQh1HTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_D5BCD39D-61A8-49BA-8AC1-477D27500F0D" id="_pgQh1XTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9C6C7F2A-9459-40DE-9675-DDA5CB1A0CD6" id="_pgQh1nTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_C17A804A-5140-4FF4-9F27-3608B2F8D4A3" id="_pgQh13TaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_AB7869E8-1143-43A1-8F62-EB0FEE4E131D" id="_pgQh2HTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_EAB2BE48-6748-4C2E-91E1-D27C080E96FA" id="_pgQh2XTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_C970DF27-4230-4477-9D81-0C34636CE8BB" id="_pgQh2nTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_41A836D9-83C2-4B6B-A2CB-FB392E62C6EA" id="_pgQh23TaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_BCAF7A70-3871-44F5-9E24-1A87D436FF93" id="_pgQh3HTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_pgQh3XTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_05EE3913-3EAD-424B-92DC-6465CFA11A50" id="_pgQh3nTaEeaoApuNXeI-uQ">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_9BE0054F-3EA1-415D-80F5-3DB0770FA1C0" id="_pgQh33TaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_A55CA959-D4DA-403D-8F0B-2078F58D2DDE" id="_pgQh4HTaEeaoApuNXeI-uQ">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_pgP6sHTaEeaoApuNXeI-uQ</bpmn2:source>
+    <bpmn2:target>_pgP6sHTaEeaoApuNXeI-uQ</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
+++ b/jbpm-flow-builder/src/main/java/org/jbpm/compiler/ProcessBuilderImpl.java
@@ -480,7 +480,7 @@ public class ProcessBuilderImpl implements org.drools.compiler.compiler.ProcessB
             return "";
         } else {
             return
-                "rule \"RuleFlowStateEventSubProcess-" + process.getId() + "-" + compositeNode.getUniqueId() + "\" @Propagation(EAGER) \n" +
+                "rule \"RuleFlowStateEventSubProcess-Event-" + process.getId() + "-" + compositeNode.getUniqueId() + "\" @Propagation(EAGER) \n" +
                 "      ruleflow-group \"DROOLS_SYSTEM\" \n" +
                 "    when \n" +
                 "      " + condition + "\n" +

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/EventSubProcessNode.java
@@ -74,7 +74,7 @@ public class EventSubProcessNode extends CompositeContextNode {
                 return true;
             }
         }
-        return false;
+        return super.acceptsEvent(type, event);
     }
     
 }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/impl/WorkflowProcessInstanceImpl.java
@@ -496,15 +496,17 @@ public abstract class WorkflowProcessInstanceImpl extends ProcessInstanceImpl
 			                if (node instanceof EventNode && ((EventNode) node).getFrom() == null) {
 			                    EventNodeInstance eventNodeInstance = (EventNodeInstance) getNodeInstance(node);
 			                    eventNodeInstance.signalEvent(type, event);
-			                } else if (node instanceof EventSubProcessNode ) {
-			                    EventSubProcessNodeInstance eventNodeInstance = (EventSubProcessNodeInstance) getNodeInstance(node);
-			                    eventNodeInstance.signalEvent(type, event);
-			                }  else {
-								List<NodeInstance> nodeInstances = getNodeInstances(node.getId(), currentView);
-			                    if (nodeInstances != null && !nodeInstances.isEmpty()) {
-			                        for (NodeInstance nodeInstance : nodeInstances) {
-										((EventNodeInstanceInterface) nodeInstance).signalEvent(type, event);
-			                        }
+			                } else {
+			                    if (node instanceof EventSubProcessNode && (((EventSubProcessNode) node).getEvents().contains(type))) {
+    			                    EventSubProcessNodeInstance eventNodeInstance = (EventSubProcessNodeInstance) getNodeInstance(node);
+    			                    eventNodeInstance.signalEvent(type, event);
+			                    } else {
+    								List<NodeInstance> nodeInstances = getNodeInstances(node.getId(), currentView);
+    			                    if (nodeInstances != null && !nodeInstances.isEmpty()) {
+    			                        for (NodeInstance nodeInstance : nodeInstances) {
+    										((EventNodeInstanceInterface) nodeInstance).signalEvent(type, event);
+    			                        }
+    			                    }
 			                    }
 			                }
 			            }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventSubProcessNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/EventSubProcessNodeInstance.java
@@ -47,13 +47,16 @@ public class EventSubProcessNodeInstance extends CompositeContextNodeInstance {
 
     @Override
     public void signalEvent(String type, Object event) {
-        if (getNodeInstanceContainer().getNodeInstances().contains(this) || type.startsWith("Error-")) {
+        if (getNodeInstanceContainer().getNodeInstances().contains(this) || type.startsWith("Error-") || type.equals("timerTriggered") ) {
             StartNode startNode = getCompositeNode().findStartNode();
-            NodeInstance nodeInstance = getNodeInstance(startNode);  
-            ((StartNodeInstance) nodeInstance).signalEvent(type, event);
+            if (((EventSubProcessNode) getEventBasedNode()).getEvents().contains(type) || type.equals("timerTriggered")) {
+                NodeInstance nodeInstance = getNodeInstance(startNode);
+                ((StartNodeInstance) nodeInstance).signalEvent(type, event);
+            }
         }
+        super.signalEvent(type, event);
     }
-
+    
     @Override
     public void nodeInstanceCompleted(org.jbpm.workflow.instance.NodeInstance nodeInstance, String outType) {
         if (nodeInstance instanceof EndNodeInstance) { 

--- a/jbpm-installer/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
+++ b/jbpm-installer/db/ddl-scripts/mysql5/mysql5-jbpm-schema.sql
@@ -2,6 +2,7 @@
         id bigint not null auto_increment,
         accessType integer,
         attachedAt datetime,
+        -- attachedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
         attachmentContentId bigint not null,
         contentType varchar(255),
         name varchar(255),
@@ -14,12 +15,15 @@
     create table AuditTaskImpl (
         id bigint not null auto_increment,
         activationTime datetime,
+        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         actualOwner varchar(255),
         createdBy varchar(255),
         createdOn datetime,
+        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
         deploymentId varchar(255),
         description varchar(255),
         dueDate datetime,
+        -- dueDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         name varchar(255),
         parentId bigint not null,
         priority integer not null,
@@ -35,10 +39,13 @@
     create table BAMTaskSummary (
         pk bigint not null auto_increment,
         createdDate datetime,
+        -- createdDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         duration bigint,
         endDate datetime,
+        -- endDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         processInstanceId bigint not null,
         startDate datetime,
+        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         status varchar(255),
         taskId bigint not null,
         taskName varchar(255),
@@ -90,6 +97,7 @@
     create table Deadline (
         id bigint not null auto_increment,
         deadline_date datetime,
+        -- deadline_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         escalated smallint,
         Deadlines_StartDeadLine_Id bigint,
         Deadlines_EndDeadLine_Id bigint,
@@ -108,6 +116,7 @@
         deploymentUnit longtext,
         state integer,
         updateDate datetime,
+        -- updateDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         primary key (id)
     );
 
@@ -116,6 +125,7 @@
         message varchar(255),
         stacktrace varchar(5000),
         timestamp datetime,
+        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
         REQUEST_ID bigint not null,
         primary key (id)
     );
@@ -153,6 +163,7 @@
         id bigint not null auto_increment,
         connection varchar(255),
         log_date datetime,
+        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         externalId varchar(255),
         nodeId varchar(255),
         nodeInstanceId varchar(255),
@@ -224,10 +235,13 @@
     create table ProcessInstanceInfo (
         InstanceId bigint not null auto_increment,
         lastModificationDate datetime,
+        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         lastReadDate datetime,
+        -- lastReadDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         processId varchar(255),
         processInstanceByteArray longblob,
         startDate datetime,
+        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         state integer not null,
         OPTLOCK integer,
         primary key (InstanceId)
@@ -238,6 +252,7 @@
         correlationKey varchar(255),
         duration bigint,
         end_date datetime,
+        -- end_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         externalId varchar(255),
         user_identity varchar(255),
         outcome varchar(255),
@@ -248,6 +263,7 @@
         processName varchar(255),
         processVersion varchar(255),
         start_date datetime,
+        -- start_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         status integer,
         primary key (id)
     );
@@ -285,14 +301,17 @@
         retries integer not null,
         status varchar(255),
         timestamp datetime,
+        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
         primary key (id)
     );
 
     create table SessionInfo (
         id bigint not null auto_increment,
         lastModificationDate datetime,
+        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         rulesByteArray longblob,
         startDate datetime,
+        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         OPTLOCK integer,
         primary key (id)
     );
@@ -308,12 +327,15 @@
         subTaskStrategy varchar(255),
         subject varchar(255),
         activationTime datetime,
+        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         createdOn datetime,
+        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
         deploymentId varchar(255),
         documentAccessType integer,
         documentContentId bigint not null,
         documentType varchar(255),
         expirationTime datetime,
+        -- expirationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         faultAccessType integer,
         faultContentId bigint not null,
         faultName varchar(255),
@@ -347,6 +369,7 @@
     create table TaskEvent (
         id bigint not null auto_increment,
         logTime datetime,
+        -- logTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         message varchar(255),
         processInstanceId bigint,
         taskId bigint,
@@ -360,6 +383,7 @@
     create table TaskVariableImpl (
         id bigint not null auto_increment,
         modificationDate datetime,
+        -- modificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         name varchar(255),
         processId varchar(255),
         processInstanceId bigint,
@@ -372,6 +396,7 @@
     create table VariableInstanceLog (
         id bigint not null auto_increment,
         log_date datetime,
+        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         externalId varchar(255),
         oldValue varchar(255),
         processId varchar(255),
@@ -385,6 +410,7 @@
     create table WorkItemInfo (
         workItemId bigint not null auto_increment,
         creationDate datetime,
+        -- creationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         name varchar(255),
         processInstanceId bigint not null,
         state bigint not null,
@@ -406,6 +432,7 @@
     create table task_comment (
         id bigint not null auto_increment,
         addedAt datetime,
+        -- addedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
         text longtext,
         addedBy_id varchar(255),
         TaskData_Comments_Id bigint,

--- a/jbpm-installer/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
+++ b/jbpm-installer/db/ddl-scripts/mysqlinnodb/mysql-innodb-jbpm-schema.sql
@@ -2,6 +2,7 @@
         id bigint not null auto_increment,
         accessType integer,
         attachedAt datetime,
+        -- attachedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
         attachmentContentId bigint not null,
         contentType varchar(255),
         name varchar(255),
@@ -14,12 +15,15 @@
     create table AuditTaskImpl (
         id bigint not null auto_increment,
         activationTime datetime,
+        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         actualOwner varchar(255),
         createdBy varchar(255),
         createdOn datetime,
+        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
         deploymentId varchar(255),
         description varchar(255),
         dueDate datetime,
+        -- dueDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         name varchar(255),
         parentId bigint not null,
         priority integer not null,
@@ -35,10 +39,13 @@
     create table BAMTaskSummary (
         pk bigint not null auto_increment,
         createdDate datetime,
+        -- createdDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         duration bigint,
         endDate datetime,
+        -- endDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         processInstanceId bigint not null,
         startDate datetime,
+        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         status varchar(255),
         taskId bigint not null,
         taskName varchar(255),
@@ -90,6 +97,7 @@
     create table Deadline (
         id bigint not null auto_increment,
         deadline_date datetime,
+        -- deadline_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         escalated smallint,
         Deadlines_StartDeadLine_Id bigint,
         Deadlines_EndDeadLine_Id bigint,
@@ -108,6 +116,7 @@
         deploymentUnit longtext,
         state integer,
         updateDate datetime,
+        -- updateDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         primary key (id)
     ) ENGINE=InnoDB;
 
@@ -116,6 +125,7 @@
         message varchar(255),
         stacktrace varchar(5000),
         timestamp datetime,
+        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
         REQUEST_ID bigint not null,
         primary key (id)
     ) ENGINE=InnoDB;
@@ -153,6 +163,7 @@
         id bigint not null auto_increment,
         connection varchar(255),
         log_date datetime,
+        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         externalId varchar(255),
         nodeId varchar(255),
         nodeInstanceId varchar(255),
@@ -224,10 +235,13 @@
     create table ProcessInstanceInfo (
         InstanceId bigint not null auto_increment,
         lastModificationDate datetime,
+        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         lastReadDate datetime,
+        -- lastReadDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         processId varchar(255),
         processInstanceByteArray longblob,
         startDate datetime,
+        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         state integer not null,
         OPTLOCK integer,
         primary key (InstanceId)
@@ -238,6 +252,7 @@
         correlationKey varchar(255),
         duration bigint,
         end_date datetime,
+        -- end_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         externalId varchar(255),
         user_identity varchar(255),
         outcome varchar(255),
@@ -248,6 +263,7 @@
         processName varchar(255),
         processVersion varchar(255),
         start_date datetime,
+        -- start_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         status integer,
         primary key (id)
     ) ENGINE=InnoDB;
@@ -285,14 +301,17 @@
         retries integer not null,
         status varchar(255),
         timestamp datetime,
+        -- timestamp datetime(6), to be used with mysql 5.6.4 that supports millis precision
         primary key (id)
     ) ENGINE=InnoDB;
 
     create table SessionInfo (
         id bigint not null auto_increment,
         lastModificationDate datetime,
+        -- lastModificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         rulesByteArray longblob,
         startDate datetime,
+        -- startDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         OPTLOCK integer,
         primary key (id)
     ) ENGINE=InnoDB;
@@ -308,12 +327,15 @@
         subTaskStrategy varchar(255),
         subject varchar(255),
         activationTime datetime,
+        -- activationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         createdOn datetime,
+        -- createdOn datetime(6), to be used with mysql 5.6.4 that supports millis precision
         deploymentId varchar(255),
         documentAccessType integer,
         documentContentId bigint not null,
         documentType varchar(255),
         expirationTime datetime,
+        -- expirationTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         faultAccessType integer,
         faultContentId bigint not null,
         faultName varchar(255),
@@ -347,6 +369,7 @@
     create table TaskEvent (
         id bigint not null auto_increment,
         logTime datetime,
+        -- logTime datetime(6), to be used with mysql 5.6.4 that supports millis precision
         message varchar(255),
         processInstanceId bigint,
         taskId bigint,
@@ -355,11 +378,12 @@
         OPTLOCK integer,
         workItemId bigint,
         primary key (id)
-    ) ENGINE=InnoDB;
+    );
 
     create table TaskVariableImpl (
         id bigint not null auto_increment,
         modificationDate datetime,
+        -- modificationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         name varchar(255),
         processId varchar(255),
         processInstanceId bigint,
@@ -372,6 +396,7 @@
     create table VariableInstanceLog (
         id bigint not null auto_increment,
         log_date datetime,
+        -- log_date datetime(6), to be used with mysql 5.6.4 that supports millis precision
         externalId varchar(255),
         oldValue varchar(255),
         processId varchar(255),
@@ -385,6 +410,7 @@
     create table WorkItemInfo (
         workItemId bigint not null auto_increment,
         creationDate datetime,
+        -- creationDate datetime(6), to be used with mysql 5.6.4 that supports millis precision
         name varchar(255),
         processInstanceId bigint not null,
         state bigint not null,
@@ -406,6 +432,7 @@
     create table task_comment (
         id bigint not null auto_increment,
         addedAt datetime,
+        -- addedAt datetime(6), to be used with mysql 5.6.4 that supports millis precision
         text longtext,
         addedBy_id varchar(255),
         TaskData_Comments_Id bigint,


### PR DESCRIPTION
RHBPMS-4208 - [GSS] (6.3.z) Unable to get log tables precision up to milliseconds when using MariaDB/MySQL
RHBPMS-4262 - [GSS] (6.3.z) Signal not getting invoked externally through rest API when it is in Error Scenario