### PR TITLE
Fixed tests that use DBs. 

### DIFF
--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/AbstractAuditLogServiceTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/AbstractAuditLogServiceTest.java
@@ -19,6 +19,7 @@ package org.jbpm.process.audit;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.drools.core.io.impl.ClassPathResource;
+import org.hamcrest.core.AnyOf;
+import org.hamcrest.core.Is;
 import org.jbpm.process.instance.impl.demo.SystemOutWorkItemHandler;
 import org.jbpm.test.util.AbstractBaseTest;
 import org.kie.api.KieBase;
@@ -483,7 +486,8 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
         VariableInstanceLog var = listVariables.get(0);
         
         assertEquals("One", var.getValue());
-        assertEquals("", var.getOldValue());
+        // Various DBs return various empty values. (E.g. Oracle returns null.)
+        assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
         assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
         assertEquals(processInstance.getProcessId(), var.getProcessId());
         assertEquals("list[0]", var.getVariableId());
@@ -491,7 +495,7 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
         
         var = listVariables.get(1);
         assertEquals("Two", var.getValue());
-        assertEquals("", var.getOldValue());
+        assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
         assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
         assertEquals(processInstance.getProcessId(), var.getProcessId());
         assertEquals("list[1]", var.getVariableId());
@@ -499,7 +503,7 @@ public abstract class AbstractAuditLogServiceTest extends AbstractBaseTest {
         
         var = listVariables.get(2);        
         assertEquals("Three", var.getValue());
-        assertEquals("", var.getOldValue());
+        assertThat(var.getOldValue(), AnyOf.anyOf(Is.is(""), Is.is((String) null), Is.is(" ")));
         assertEquals(processInstance.getId(), var.getProcessInstanceId().longValue());
         assertEquals(processInstance.getProcessId(), var.getProcessId());
         assertEquals("list[2]", var.getVariableId());

--- a/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryTest.java
+++ b/jbpm-audit/src/test/java/org/jbpm/process/audit/query/AuditQueryTest.java
@@ -497,39 +497,44 @@ public class AuditQueryTest extends JPAAuditLogService {
     }
 
     @Test
-    public void orderByQueryBuilderTest() { 
-       ProcessInstanceLogQueryBuilder builder = this.processInstanceLogQuery();
-       List<org.kie.api.runtime.manager.audit.ProcessInstanceLog> resultList = builder.build().getResultList();
-       for( int i = 1; i < resultList.size(); ++i ) { 
-          ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
-          ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i-1);
-          assertTrue( pilA.getId() < pilB.getId() );
-       }
-       
-       builder.ascending(OrderBy.processInstanceId);
-       resultList = builder.build().getResultList();
-       for( int i = 1; i < resultList.size(); ++i ) { 
-          ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
-          ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i-1);
-          assertTrue( "order by process instance id failed:  " + pilA.getProcessInstanceId() + " ? " +  pilB.getProcessInstanceId(),
-                  pilA.getProcessInstanceId() <= pilB.getProcessInstanceId() );
-       }
-       
-       builder.descending(OrderBy.processInstanceId);
-       resultList = builder.build().getResultList();
-       for( int i = 1; i < resultList.size(); ++i ) { 
-          ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
-          ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i-1);
-          assertTrue( "order desc by process instance id failed", pilA.getProcessInstanceId() >= pilB.getProcessInstanceId() );
-       }
-      
-       builder.ascending(OrderBy.processId);
-       resultList = builder.build().getResultList();
-       for( int i = 1; i < resultList.size(); ++i ) { 
-          ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i-1);
-          ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
-          assertTrue( "order desc by process id failed", pilA.getProcessId().compareTo(pilB.getProcessId()) <= 0 );
-       }
+    public void orderByQueryBuilderTest() {
+        ProcessInstanceLogQueryBuilder builder = this.processInstanceLogQuery();
+
+        builder.ascending(OrderBy.processInstanceId);
+        List<org.kie.api.runtime.manager.audit.ProcessInstanceLog> resultList = builder.build().getResultList();
+        for (int i = 1; i < resultList.size(); ++i) {
+            ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
+            ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i - 1);
+            assertTrue("order by asc process instance id failed: " + pilA.getProcessInstanceId() + " ? " + pilB.getProcessInstanceId(),
+                    pilA.getProcessInstanceId() <= pilB.getProcessInstanceId());
+        }
+
+        builder.descending(OrderBy.processInstanceId);
+        resultList = builder.build().getResultList();
+        for (int i = 1; i < resultList.size(); ++i) {
+            ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
+            ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i - 1);
+            assertTrue("order by desc process instance id failed: " + pilA.getProcessInstanceId() + " ? " + pilB.getProcessInstanceId(),
+                    pilA.getProcessInstanceId() >= pilB.getProcessInstanceId());
+        }
+
+        builder.ascending(OrderBy.processId);
+        resultList = builder.build().getResultList();
+        for (int i = 1; i < resultList.size(); ++i) {
+            ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i - 1);
+            ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
+            assertTrue("order by asc process id failed: " + pilA.getProcessId() + " ? " + pilB.getProcessId(),
+                    pilA.getProcessId().compareTo(pilB.getProcessId()) <= 0);
+        }
+
+        builder.descending(OrderBy.processId);
+        resultList = builder.build().getResultList();
+        for (int i = 1; i < resultList.size(); ++i) {
+            ProcessInstanceLog pilA = (ProcessInstanceLog) resultList.get(i - 1);
+            ProcessInstanceLog pilB = (ProcessInstanceLog) resultList.get(i);
+            assertTrue("order by desc process id failed: " + pilA.getProcessId() + " ? " + pilB.getProcessId(),
+                    pilA.getProcessId().compareTo(pilB.getProcessId()) >= 0);
+        }
     }
    
     @Test

--- a/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/SQLScriptUtil.java
+++ b/jbpm-installer/src/test/java/org/jbpm/persistence/scripts/util/SQLScriptUtil.java
@@ -37,13 +37,14 @@ public final class SQLScriptUtil {
         final StringBuilder command = new StringBuilder();
         for (String line : scriptLines) {
             // Ignore comments.
-            if (line.trim().startsWith("--") || line.trim().startsWith("#")) {
+            final String trimmedLine = line.trim();
+            if ("".equals(trimmedLine) || trimmedLine.startsWith("--") || trimmedLine.startsWith("#")) {
                 continue;
             }
             // If the whole line is a delimiter -> add buffered command to found commands.
-            if (line.equals(DELIMITER_STANDARD)
+            if (trimmedLine.equals(DELIMITER_STANDARD)
                     || ((databaseType == DatabaseType.SQLSERVER || databaseType == DatabaseType.SQLSERVER2008)
-                            && line.equals(DELIMITER_MSSQL))) {
+                            && trimmedLine.equals(DELIMITER_MSSQL))) {
                 if (!"".equals(command.toString())) {
                     foundCommands.add(command.toString());
                     command.setLength(0);
@@ -51,13 +52,13 @@ public final class SQLScriptUtil {
                 }
             }
             // Split line by delimiter.
-            if (line.contains(DELIMITER_STANDARD)) {
-                extractCommandsFromLine(line, "\\" + DELIMITER_STANDARD, command, foundCommands);
+            if (trimmedLine.contains(DELIMITER_STANDARD)) {
+                extractCommandsFromLine(trimmedLine, "\\" + DELIMITER_STANDARD, command, foundCommands);
             } else if ((databaseType == DatabaseType.SQLSERVER || databaseType == DatabaseType.SQLSERVER2008)
-                    && line.contains(DELIMITER_MSSQL)) {
-                extractCommandsFromLine(line, DELIMITER_MSSQL, command, foundCommands);
+                    && trimmedLine.contains(DELIMITER_MSSQL)) {
+                extractCommandsFromLine(trimmedLine, DELIMITER_MSSQL, command, foundCommands);
             } else {
-                command.append(line).append(" ");
+                command.append(trimmedLine).append(" ");
             }
         }
         // If there's still some buffered command, add it to found commands.


### PR DESCRIPTION
- Fixed handling of empty lines in upgrade SQL scripts tests.
- Fixed order by test - first test case from this test wasn't needed because it hadn't any order by - this failed sometimes because each DB can have different default ordering. 
- Fixed handling empty values from various DBs in AbstractAuditLogServiceTest.

I didn't create JIRA for this, because it's just test fixes. If it is needed, I'll create one. 