### PR TITLE
JBPM-4646 - Case management - improved handling of missing comments

### DIFF
--- a/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/CaseCommentNotFoundException.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/CaseCommentNotFoundException.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.casemgmt.api;
+
+/**
+ * Thrown then accessing or manipulating case comment that does not exist
+ *
+ */
+public class CaseCommentNotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = -6105558767536810447L;
+
+    public CaseCommentNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public CaseCommentNotFoundException(String message) {
+        super(message);
+    }
+
+}

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/CaseCommentCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/CaseCommentCommand.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 
 import org.drools.core.ClassObjectFilter;
 import org.drools.core.command.impl.KnowledgeCommandContext;
+import org.jbpm.casemgmt.api.CaseCommentNotFoundException;
 import org.jbpm.casemgmt.api.model.instance.CaseFileInstance;
 import org.jbpm.casemgmt.api.model.instance.CommentInstance;
 import org.jbpm.casemgmt.impl.event.CaseEventSupport;
@@ -87,7 +88,7 @@ public class CaseCommentCommand extends CaseCommand<Void> {
             CommentInstance toUpdate = ((CaseFileInstanceImpl)caseFile).getComments().stream()
                     .filter(c -> c.getId().equals(commentId))
                     .findFirst()
-                    .get();
+                    .orElseThrow(() -> new CaseCommentNotFoundException("Cannot find comment with id " + commentId));
             if (!this.author.equals(toUpdate.getAuthor())) {
                 throw new IllegalStateException("Only original author can update comment");
             }
@@ -98,7 +99,7 @@ public class CaseCommentCommand extends CaseCommand<Void> {
             CommentInstance toRemove = ((CaseFileInstanceImpl)caseFile).getComments().stream()
                     .filter(c -> c.getId().equals(commentId))
                     .findFirst()
-                    .get();
+                    .orElseThrow(() -> new CaseCommentNotFoundException("Cannot find comment with id " + commentId));
             caseEventSupport.fireBeforeCaseCommentRemoved(caseFile.getCaseId(), toRemove);
             ((CaseFileInstanceImpl)caseFile).removeComment(toRemove);            
             caseEventSupport.fireBeforeCaseCommentRemoved(caseFile.getCaseId(), toRemove);

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseServiceImplTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseServiceImplTest.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 
 import org.drools.compiler.kie.builder.impl.InternalKieModule;
 import org.jbpm.casemgmt.api.CaseActiveException;
+import org.jbpm.casemgmt.api.CaseCommentNotFoundException;
 import org.jbpm.casemgmt.api.CaseNotFoundException;
 import org.jbpm.casemgmt.api.model.AdHocFragment;
 import org.jbpm.casemgmt.api.model.CaseDefinition;
@@ -949,6 +950,56 @@ public class CaseServiceImplTest extends AbstractCaseServicesBaseTest {
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);
             fail("Unexpected exception " + e.getMessage());
+        } finally {
+            if (caseId != null) {
+                caseService.cancelCase(caseId);
+            }
+        }
+    }
+
+    @Test
+    public void testUpdateNotExistingCaseComment() {
+        assertNotNull(deploymentService);
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        Map<String, Object> data = new HashMap<>();
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(), USER_TASK_STAGE_AUTO_START_CASE_P_ID, data);
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), USER_TASK_STAGE_AUTO_START_CASE_P_ID, caseFile);
+        assertNotNull(caseId);
+        assertEquals(FIRST_CASE_ID, caseId);
+        try {
+            caseService.updateCaseComment(FIRST_CASE_ID, "not-existing-comment", "poul", "just a tiny comment");
+            fail("Not existing comment cannot be updated.");
+        } catch (CaseCommentNotFoundException e) {
+            // expected
+        } finally {
+            if (caseId != null) {
+                caseService.cancelCase(caseId);
+            }
+        }
+    }
+
+    @Test
+    public void testRemoveNotExistingCaseComment() {
+        assertNotNull(deploymentService);
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        Map<String, Object> data = new HashMap<>();
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(), USER_TASK_STAGE_AUTO_START_CASE_P_ID, data);
+
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), USER_TASK_STAGE_AUTO_START_CASE_P_ID, caseFile);
+        assertNotNull(caseId);
+        assertEquals(FIRST_CASE_ID, caseId);
+        try {
+            caseService.removeCaseComment(FIRST_CASE_ID, "not-existing-comment");
+            fail("Not existing comment cannot be deleted.");
+        } catch (CaseCommentNotFoundException e) {
+            // expected
         } finally {
             if (caseId != null) {
                 caseService.cancelCase(caseId);


### PR DESCRIPTION
If user tried to update or delete not existing comment then NoSuchElementException was thrown.