### PR TITLE
Add revapi plugin to check public API in jbpm-services-api module

### DIFF
--- a/jbpm-services/jbpm-services-api/pom.xml
+++ b/jbpm-services/jbpm-services-api/pom.xml
@@ -46,6 +46,43 @@
           </instructions>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+        <configuration>
+          <oldArtifacts>
+            <artifact>${project.groupId}:${project.artifactId}:${version.org.kie.latestFinal.release}</artifact>
+          </oldArtifacts>
+          <!-- By default revapi will check the oldArtifact against the currently executed build -->
+          <analysisConfigurationFiles>
+            <configurationFile>
+              <path>src/build/revapi-config.json</path>
+            </configurationFile>
+          </analysisConfigurationFiles>
+        </configuration>
+        <!-- Running two executions is a workaround to make sure we get a HTML report in case revapi finds
+             some incompatible changes. The "check" goal will simply fail the whole build before it could get
+             to the report. To make sure we always get a HTML report, the "report" goal needs to be executed
+             before the "check" goal.
+             Once https://github.com/revapi/revapi/issues/11 is fixed it should be possible to use single execution. -->
+        <executions>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+          <execution>
+            <!-- report can be found in ${build.directory}/site/revapi-report.html -->
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>package</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/jbpm-services/jbpm-services-api/src/build/revapi-config.json
+++ b/jbpm-services/jbpm-services-api/src/build/revapi-config.json
@@ -1,0 +1,48 @@
+{
+  "revapi": {
+    "_comment": "Changes between 6.4.0.Final and master. These changes are desired and thus ignored. They should be removed when 7.0.0.Final is available.",
+    "ignore": [
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<org.jbpm.services.api.model.NodeInstanceDesc> org.jbpm.services.api.RuntimeDataService::getNodeInstancesByCorrelationKeyNodeType(org.kie.internal.process.CorrelationKey, java.util.List<java.lang.Integer>, java.util.List<java.lang.String>, org.kie.api.runtime.query.QueryContext)",
+        "justification": "Added as it's required by case management to efficiently find node instance of given type for a case"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<org.jbpm.services.api.model.NodeInstanceDesc> org.jbpm.services.api.RuntimeDataService::getNodeInstancesByNodeType(long, java.util.List<java.lang.String>, org.kie.api.runtime.query.QueryContext)",
+        "justification": "Added as it's required by case management to efficiently find node instance of given type for a case"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<org.jbpm.services.api.model.ProcessInstanceDesc> org.jbpm.services.api.RuntimeDataService::getProcessInstancesByCorrelationKeyAndStatus(org.kie.internal.process.CorrelationKey, java.util.List<java.lang.Integer>, org.kie.api.runtime.query.QueryContext)",
+        "justification": "Needed for case mgmt to find all instances belonging to a case instance with status filtering"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<java.lang.String> org.jbpm.services.api.model.ProcessDefinition::getGlobals()",
+        "justification": "Required by change impact support to find all process definitions that might be affected in case of refactoring"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<java.lang.String> org.jbpm.services.api.model.ProcessDefinition::getReferencedRules()",
+        "justification": "Required by change impact support to find all process definitions that might be affected in case of refactoring"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method java.util.Collection<java.lang.String> org.jbpm.services.api.model.ProcessDefinition::getSignals()",
+        "justification": "Required by change impact support to find all process definitions that might be affected in case of refactoring"
+      },
+      {
+        "code": "java.method.addedToInterface",
+        "new": "method boolean org.jbpm.services.api.model.ProcessDefinition::isDynamic()",
+        "justification": "Used by case mgmt to identify process as case - being dynamic"
+      },
+      {
+        "code": "java.field.constantValueChanged",
+        "old": "field org.jbpm.services.api.query.QueryResultMapper<T>.COLUMN_ORGANIZATIONAL_ENTITY",
+        "new": "field org.jbpm.services.api.query.QueryResultMapper<T>.COLUMN_ORGANIZATIONAL_ENTITY",
+        "justification": "Fix for some of dbs with query aliases"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Hi, @mswiderski,

here is the revapi plugin configured for jbpm-services-api module. Thanks for justifications you made. Please wait for this PR droolsjbpm/droolsjbpm-build-bootstrap#303 to be merged, so we have the most up-to-date version tested.

Marian
