### PR TITLE
[JBPM-5285] Custom JNDI name for AvailableJobsExecutor in ExecutorServiceFactory

### DIFF
--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/ExecutorServiceFactory.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/ExecutorServiceFactory.java
@@ -51,7 +51,7 @@ public class ExecutorServiceFactory {
 	private final static String mode = System.getProperty( "org.jbpm.cdi.executor.mode", "singleton" );
 	
 	private final static String availableJobsExecutorName = System.getProperty(
-	    "org.jbpm.cdi.available.jobs.executor.name", "java:module/AvailableJobsExecutor" );
+	    "org.jbpm.cdi.executor.jndi", "java:module/AvailableJobsExecutor" );
 
 	private static final Logger logger = LoggerFactory.getLogger(ExecutorServiceFactory.class);
    

--- a/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/ExecutorServiceFactory.java
+++ b/jbpm-services/jbpm-executor/src/main/java/org/jbpm/executor/ExecutorServiceFactory.java
@@ -49,6 +49,9 @@ import org.slf4j.LoggerFactory;
 public class ExecutorServiceFactory {
 
 	private final static String mode = System.getProperty( "org.jbpm.cdi.executor.mode", "singleton" );
+	
+	private final static String availableJobsExecutorName = System.getProperty(
+	    "org.jbpm.cdi.available.jobs.executor.name", "java:module/AvailableJobsExecutor" );
 
 	private static final Logger logger = LoggerFactory.getLogger(ExecutorServiceFactory.class);
    
@@ -150,7 +153,7 @@ public class ExecutorServiceFactory {
         AvailableJobsExecutor jobExecutor = null;
 
         try {
-            jobExecutor = InitialContext.doLookup("java:module/AvailableJobsExecutor");
+            jobExecutor = InitialContext.doLookup(availableJobsExecutorName);
         } catch (Exception e) {
             jobExecutor = buildJobExecutor(emf, eventSupport);
         }
@@ -190,7 +193,7 @@ public class ExecutorServiceFactory {
     	ExecutorRunnable runnable = new ExecutorRunnable();
     	AvailableJobsExecutor jobExecutor = null;
     	try {
-    		jobExecutor = InitialContext.doLookup("java:module/AvailableJobsExecutor");
+    		jobExecutor = InitialContext.doLookup(availableJobsExecutorName);
     	} catch (Exception e) {
     		jobExecutor = new AvailableJobsExecutor();
 	    	ClassCacheManager classCacheManager = new ClassCacheManager();


### PR DESCRIPTION
This PR allows to define the JNDI lookup name of AvailableJobsExecutor implementation in ExecutorServiceFactory, thus allowing to load a customized implementation