### PR TITLE
Use project version for test artifacts

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -54,19 +54,19 @@
       <dependency>
         <groupId>org.jbpm</groupId>
         <artifactId>test-kjar-integration</artifactId>
-        <version>${version.test.kjar}</version>
+        <version>${project.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.jbpm</groupId>
         <artifactId>test-kjar-evaluation</artifactId>
-        <version>${version.test.kjar}</version>
+        <version>${project.version}</version>
         <scope>runtime</scope>
       </dependency>
       <dependency>
         <groupId>org.jbpm</groupId>
         <artifactId>test-kjar-bpmn-build</artifactId>
-        <version>${version.test.kjar}</version>
+        <version>${project.version}</version>
         <scope>runtime</scope>
       </dependency>
 

--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/src/test/java/org/jbpm/remote/ejb/test/TestKjars.java
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/src/test/java/org/jbpm/remote/ejb/test/TestKjars.java
@@ -21,7 +21,9 @@ import org.jbpm.remote.ejb.test.maven.MavenProject;
 
 public class TestKjars {
 
-    public static final MavenProject INTEGRATION = new MavenProject("org.jbpm:test-kjar-integration:1.0.0");
-    public static final MavenProject BPMN_BUILD_TEST = new MavenProject("org.jbpm:test-kjar-bpmn-build:1.0.0");
-    public static final MavenProject EVALUATION = new MavenProject("org.jbpm:test-kjar-evaluation:1.0.0");
+    private static final String KJAR_VERSION = System.getProperty("project.version");
+
+    public static final MavenProject INTEGRATION = new MavenProject("org.jbpm:test-kjar-integration:" + KJAR_VERSION);
+    public static final MavenProject BPMN_BUILD_TEST = new MavenProject("org.jbpm:test-kjar-bpmn-build:" + KJAR_VERSION);
+    public static final MavenProject EVALUATION = new MavenProject("org.jbpm:test-kjar-evaluation:" + KJAR_VERSION);
 }

--- a/jbpm-container-test/jbpm-remote-ejb-test/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/pom.xml
@@ -14,10 +14,6 @@
   <name>jBPM :: jBPM Remote EJB tests and resources</name>
   <description>Test suite for jBPM Remote EJB</description>
 
-  <properties>
-    <version.test.kjar>1.0.0</version.test.kjar>
-  </properties>
-
   <modules>
     <module>jbpm-remote-ejb-test-domain</module>
     <module>test-kjar-parent</module>

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <artifactId>test-kjar-parent</artifactId>
-  <version>1.0.0</version>
   <packaging>pom</packaging>
 
   <modules>

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-bpmn-build/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-bpmn-build/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>test-kjar-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>1.0.0</version>
+    <version>7.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>test-kjar-bpmn-build</artifactId>

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-evaluation/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-evaluation/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <artifactId>test-kjar-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>1.0.0</version>
+    <version>7.0.0-SNAPSHOT</version>
   </parent>
 
 

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-integration/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-integration/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>test-kjar-parent</artifactId>
     <groupId>org.jbpm</groupId>
-    <version>1.0.0</version>
+    <version>7.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Fixes the build failing due to rewrite of test artifacts version by automation scripts.