### PR TITLE
Do not use kie-maven-plugin

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/pom.xml
@@ -27,16 +27,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.kie</groupId>
-          <artifactId>kie-maven-plugin</artifactId>
-          <version>${version.org.kie}</version>
-          <extensions>true</extensions>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
 </project>

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-bpmn-build/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-bpmn-build/pom.xml
@@ -9,14 +9,5 @@
   </parent>
 
   <artifactId>test-kjar-bpmn-build</artifactId>
-  <packaging>kjar</packaging>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-evaluation/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-evaluation/pom.xml
@@ -9,16 +9,6 @@
     <version>7.0.0-SNAPSHOT</version>
   </parent>
 
-
   <artifactId>test-kjar-evaluation</artifactId>
-  <packaging>kjar</packaging>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-integration/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/test-kjar-parent/test-kjar-integration/pom.xml
@@ -11,7 +11,6 @@
 
   <name>kjar sources - integration</name>
   <artifactId>test-kjar-integration</artifactId>
-  <packaging>kjar</packaging>
 
   <dependencies>
 
@@ -22,12 +21,4 @@
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.kie</groupId>
-        <artifactId>kie-maven-plugin</artifactId>
-      </plugin>
-    </plugins>
-  </build>
 </project>


### PR DESCRIPTION
The plugin is being built after the jbpm repo
(in droolsjbpm-integration), so it can not be
used here.