### PR TITLE
Don't start/stop container with -DskipTests

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -463,5 +463,18 @@
         </pluginManagement>
       </build>
     </profile>
+
+    <profile>
+      <id>skipTests</id>
+      <activation>
+        <property>
+          <name>skipTests</name>
+        </property>
+      </activation>
+      <properties>
+        <cargo.maven.skip>true</cargo.maven.skip>
+      </properties>
+    </profile>
   </profiles>
+
 </project>


### PR DESCRIPTION
Before the change, when running `mvn clean install -DskipTests` the container would still get started/stopped, which takes considerable amount of time and is not needed in such case.

@rsynek could you please quickly check this?
