### PR TITLE
[DROOLS-1353] define ExecutableRunner interface - fix for osgi

### DIFF
--- a/jbpm-runtime-manager/pom.xml
+++ b/jbpm-runtime-manager/pom.xml
@@ -220,6 +220,7 @@
               org.drools.core.common,
               org.drools.core.impl,
               org.drools.core.marshalling.impl,
+              org.drools.core.runtime,
               org.drools.core.time,
               org.drools.core.time.impl,
               org.drools.core.util,


### PR DESCRIPTION
depends on https://github.com/droolsjbpm/drools/pull/1029