### PR TITLE
JBPM-5472: static inner classes in CompositeNode and ForEachNode

### DIFF
--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/CompositeNode.java
@@ -112,7 +112,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
 	}
     
     public void linkIncomingConnections(String inType, long inNodeId, String inNodeType) {
-        linkIncomingConnections(inType, new NodeAndType(inNodeId, inNodeType));
+        linkIncomingConnections(inType, new NodeAndType(nodeContainer, inNodeId, inNodeType));
     }
     
     public void linkIncomingConnections(String inType, CompositeNode.NodeAndType inNode) {
@@ -138,7 +138,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         if (inNode != null) {
 	        List<Connection> connections = getIncomingConnections(inType);
 	        for (Connection connection: connections) {
-	        	CompositeNodeStart start = new CompositeNodeStart(connection.getFrom(), inType);
+	        	CompositeNodeStart start = new CompositeNodeStart(this, connection.getFrom(), inType);
 		        internalAddNode(start);
 		        if (inNode.getNode() != null) {
 			        new ConnectionImpl(
@@ -150,7 +150,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
     }
     
     public void linkOutgoingConnections(long outNodeId, String outNodeType, String outType) {
-        linkOutgoingConnections(new NodeAndType(outNodeId, outNodeType), outType);
+        linkOutgoingConnections(new NodeAndType(this, outNodeId, outNodeType), outType);
     }
     
     public void linkOutgoingConnections(CompositeNode.NodeAndType outNode, String outType) {
@@ -174,7 +174,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         if (outNode != null) {
 	        List<Connection> connections = getOutgoingConnections(outType);
 	        for (Connection connection: connections) {
-		        CompositeNodeEnd end = new CompositeNodeEnd(connection.getTo(), outType);
+		        CompositeNodeEnd end = new CompositeNodeEnd(this, connection.getTo(), outType);
 		        internalAddNode(end);
 		        if (outNode.getNode() != null) {
 			        new ConnectionImpl(
@@ -232,7 +232,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
 	        super.addIncomingConnection(type, connection);
 	        CompositeNode.NodeAndType inNode = internalGetLinkedIncomingNode(type);
 	        if (inNode != null) {
-		        CompositeNodeStart start = new CompositeNodeStart(connection.getFrom(), type);
+		        CompositeNodeStart start = new CompositeNodeStart(this, connection.getFrom(), type);
 		        internalAddNode(start);
 		        NodeImpl node = (NodeImpl) inNode.getNode();
 	        	if (node != null) {
@@ -269,7 +269,7 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
 	        super.addOutgoingConnection(type, connection);
 	        CompositeNode.NodeAndType outNode = internalGetLinkedOutgoingNode(type);
 	        if (outNode != null) {
-		        CompositeNodeEnd end = new CompositeNodeEnd(connection.getTo(), type);
+		        CompositeNodeEnd end = new CompositeNodeEnd(this, connection.getTo(), type);
 		        internalAddNode(end);
 		        NodeImpl node = (NodeImpl) outNode.getNode();
 	        	if (node != null) {
@@ -359,21 +359,23 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         this.autoComplete = autoComplete;
     }
 
-    public class NodeAndType implements Serializable {
+    public static class NodeAndType implements Serializable {
 
-		private static final long serialVersionUID = 510l;
+        private static final long serialVersionUID = 510l;
 		
-		private long nodeId;
+        private NodeContainer nodeContainer;
+        private long nodeId;
         private String type;
         private transient Node node;
         
-        public NodeAndType(long nodeId, String type) {
+        public NodeAndType(NodeContainer nodeContainer, long nodeId, String type) {
             if (type == null) {
                 throw new IllegalArgumentException(
                     "Node or type may not be null!");
             }
             this.nodeId = nodeId;
             this.type = type;
+            this.nodeContainer = nodeContainer;
         }
         
         public NodeAndType(Node node, String type) {
@@ -419,25 +421,27 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         
     }
     
-    public class CompositeNodeStart extends NodeImpl {
+    public static class CompositeNodeStart extends NodeImpl {
 
         private static final long serialVersionUID = 510l;
         
+        private CompositeNode parentNode;
         private long inNodeId;
         private transient Node inNode;
         private String inType;
         
-        public CompositeNodeStart(Node outNode, String outType) {
+        public CompositeNodeStart(CompositeNode parentNode, Node outNode, String outType) {
             setName("Composite node start");
             this.inNodeId = outNode.getId();
             this.inNode = outNode;
             this.inType = outType;
+            this.parentNode = parentNode;
             setMetaData("hidden", true);
        }
         
         public Node getInNode() {
             if (inNode == null) {
-                inNode = ((NodeContainer) CompositeNode.this.getNodeContainer()).internalGetNode(inNodeId);
+                inNode = ((NodeContainer) parentNode.getNodeContainer()).internalGetNode(inNodeId);
             }
             return inNode;
         }
@@ -452,25 +456,27 @@ public class CompositeNode extends StateBasedNode implements NodeContainer, Even
         
     }
     
-    public class CompositeNodeEnd extends NodeImpl {
+    public static class CompositeNodeEnd extends NodeImpl {
 
         private static final long serialVersionUID = 510l;
         
+        private CompositeNode parentNode;
         private long outNodeId;
         private transient Node outNode;
         private String outType;
         
-        public CompositeNodeEnd(Node outNode, String outType) {
+        public CompositeNodeEnd(CompositeNode parentNode, Node outNode, String outType) {
             setName("Composite node end");
             this.outNodeId = outNode.getId();
             this.outNode = outNode;
             this.outType = outType;
+            this.parentNode = parentNode;
             setMetaData("hidden", true);
         }
         
         public Node getOutNode() {
             if (outNode == null) {
-                outNode = ((NodeContainer) CompositeNode.this.getNodeContainer()).internalGetNode(outNodeId);
+                outNode = ((NodeContainer) parentNode.getNodeContainer()).internalGetNode(outNodeId);
             }
             return outNode;
         }

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/ForEachNode.java
@@ -242,11 +242,11 @@ public class ForEachNode extends CompositeContextNode {
         this.waitForCompletion = waitForCompletion;
     }
 
-   public class ForEachSplitNode extends ExtendedNodeImpl {
+   public static class ForEachSplitNode extends ExtendedNodeImpl {
         private static final long serialVersionUID = 510l;
     }
 
-    public class ForEachJoinNode extends ExtendedNodeImpl {
+    public static class ForEachJoinNode extends ExtendedNodeImpl {
         private static final long serialVersionUID = 510l;
     }
 

--- a/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeInnerClassesTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeInnerClassesTest.java
@@ -1,0 +1,63 @@
+package org.jbpm.workflow.core.node;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.drools.core.process.core.datatype.impl.type.ObjectDataType;
+import org.jbpm.process.core.context.variable.Variable;
+import org.jbpm.process.test.TestProcessEventListener;
+import org.jbpm.ruleflow.core.RuleFlowProcess;
+import org.jbpm.test.util.AbstractBaseTest;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kie.api.runtime.KieSession;
+import org.kie.api.runtime.process.ProcessInstance;
+import org.slf4j.LoggerFactory;
+
+public class NodeInnerClassesTest extends AbstractBaseTest {
+
+	@Override
+	public void addLogger() {
+		logger = LoggerFactory.getLogger(this.getClass());
+	}
+	
+	@Test
+	public void testNodeReading() {
+
+		RuleFlowProcess process = new RuleFlowProcess();
+        process.setId("org.drools.core.process.event");
+        process.setName("Event Process");
+        
+        List<Variable> variables = new ArrayList<Variable>();
+        Variable variable = new Variable();
+        variable.setName("event");
+        ObjectDataType personDataType = new ObjectDataType();
+        personDataType.setClassName("org.drools.Person");
+        variable.setType(personDataType);
+        variables.add(variable);
+        process.getVariableScope().setVariables(variables);
+
+        CompositeNode compositeNode = new CompositeNode();
+        compositeNode.setName("CompositeNode");
+        compositeNode.setId(2);
+        
+        ForEachNode forEachNode = new ForEachNode();
+        ForEachNode.ForEachSplitNode split = new ForEachNode.ForEachSplitNode();
+        split.setName("ForEachSplit");
+        split.setMetaData("hidden", true);
+        split.setMetaData("UniqueId", forEachNode.getMetaData("Uniqueid") + ":foreach:split");
+        forEachNode.internalAddNode(split);
+        forEachNode.linkIncomingConnections(
+            org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE, 
+            new CompositeNode.NodeAndType(split, org.jbpm.workflow.core.Node.CONNECTION_DEFAULT_TYPE));
+        
+        process.addNode(forEachNode);
+        KieSession ksession = createKieSession(process); 
+        TestProcessEventListener procEventListener = new TestProcessEventListener();
+        ksession.addEventListener(procEventListener);
+        
+        ProcessInstance processInstance = ksession.startProcess("org.drools.core.process.event");
+        Assert.assertNotNull(processInstance);
+	}
+
+}

--- a/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeInnerClassesTest.java
+++ b/jbpm-flow/src/test/java/org/jbpm/workflow/core/node/NodeInnerClassesTest.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2010 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.jbpm.workflow.core.node;
 
 import java.util.ArrayList;


### PR DESCRIPTION
We're working on serialization mechanisms for the process definition, and to have them work we need to be able to recreate the inner classes of ForEachNode and CompositeNode to allow serialization /deserialization of the object to be possible from outside the class.