### PR TITLE
JBPM-5541 - Case file conditional event fails other cases

### DIFF
--- a/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
+++ b/jbpm-bpmn2/src/test/java/org/jbpm/bpmn2/ActivityTest.java
@@ -1062,7 +1062,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         assertProcessInstanceActive(processInstance);
         ksession.signalEvent("User1", null, processInstance.getId());
         assertProcessInstanceActive(processInstance);
-        ksession.insert(new Person());
+        ksession.getEntryPoint("AdHocProcess").insert(new Person());
         ksession.signalEvent("Task3", null, processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
     }
@@ -1090,7 +1090,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         ksession.getWorkItemManager().completeWorkItem(workItem.getId(), null);
         ksession.signalEvent("User1", null, processInstance.getId());
         assertProcessInstanceActive(processInstance);
-        ksession.insert(new Person());
+        ksession.getEntryPoint("AdHocProcess").insert(new Person());
         ksession.signalEvent("Task3", null, processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
     }
@@ -1116,7 +1116,7 @@ public class ActivityTest extends JbpmBpmn2TestCase {
         ksession = restoreSession(ksession, true);
         ksession.signalEvent("User1", null, processInstance.getId());
         assertProcessInstanceActive(processInstance);
-        ksession.insert(new Person());
+        ksession.getEntryPoint("AdHocProcess").insert(new Person());
         ksession.signalEvent("Task3", null, processInstance.getId());
         assertProcessInstanceFinished(processInstance, ksession);
     }

--- a/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/model/instance/CaseFileInstance.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-api/src/main/java/org/jbpm/casemgmt/api/model/instance/CaseFileInstance.java
@@ -34,6 +34,12 @@ public interface CaseFileInstance extends CaseData {
     String getCaseId();
     
     /**
+     * Returns case definition id this case instance is associated with.
+     * @return
+     */
+    String getCaseDefinitionId();
+    
+    /**
      * Returns start date of the associated case
      * @return
      */

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/AddDataCaseFileInstanceCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/AddDataCaseFileInstanceCommand.java
@@ -35,8 +35,10 @@ public class AddDataCaseFileInstanceCommand extends CaseCommand<Void> {
     private static final long serialVersionUID = 6345222909719335953L;
 
     private Map<String, Object> parameters;
+    private String caseDefinitionId;
     
-    public AddDataCaseFileInstanceCommand(Map<String, Object> parameters) {                
+    public AddDataCaseFileInstanceCommand(String caseDefinitionId, Map<String, Object> parameters) {                
+        this.caseDefinitionId = caseDefinitionId;
         this.parameters = parameters;        
     }
 
@@ -44,19 +46,19 @@ public class AddDataCaseFileInstanceCommand extends CaseCommand<Void> {
     public Void execute(Context context) {
         KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
         
-        Collection<? extends Object> caseFiles = ksession.getObjects(new ClassObjectFilter(CaseFileInstance.class));
+        Collection<? extends Object> caseFiles = ksession.getEntryPoint(caseDefinitionId).getObjects(new ClassObjectFilter(CaseFileInstance.class));
         if (caseFiles.size() != 1) {
             throw new IllegalStateException("Not able to find distinct case file - found case files " + caseFiles.size());
         }
         CaseFileInstance caseFile = (CaseFileInstance) caseFiles.iterator().next();
-        FactHandle factHandle = ksession.getFactHandle(caseFile);
+        FactHandle factHandle = ksession.getEntryPoint(caseDefinitionId).getFactHandle(caseFile);
         
         CaseEventSupport caseEventSupport = getCaseEventSupport(context);
         caseEventSupport.fireBeforeCaseDataAdded(caseFile.getCaseId(), parameters);
         caseFile.addAll(parameters);
         caseEventSupport.fireAfterCaseDataAdded(caseFile.getCaseId(), parameters);
         
-        ksession.update(factHandle, caseFile);
+        ksession.getEntryPoint(caseDefinitionId).update(factHandle, caseFile);
         return null;
     }
 

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/AddDynamicProcessCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/AddDynamicProcessCommand.java
@@ -24,6 +24,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.Context;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -38,11 +39,15 @@ public class AddDynamicProcessCommand extends CaseCommand<Long> {
     private long processInstanceId;
     private Map<String, Object> parameters;
     
-    public AddDynamicProcessCommand(String caseId, Long processInstanceId, String processId, Map<String, Object> parameters) {        
+    private String caseDefinitionId;
+    
+    public AddDynamicProcessCommand(String caseId, Long processInstanceId, String processId, Map<String, Object> parameters, String caseDefinitionId) {        
         this.caseId = caseId;
         this.processInstanceId = processInstanceId;
         this.processId = processId;
         this.parameters = parameters;
+        
+        this.caseDefinitionId = caseDefinitionId;
         
         if (processInstanceId == null || processId == null) {
             throw new IllegalArgumentException("Mandatory parameters are missing - process instance id and process id");
@@ -57,6 +62,11 @@ public class AddDynamicProcessCommand extends CaseCommand<Long> {
         if (processInstance == null) {
             throw new ProcessInstanceNotFoundException("No process instance found with id " + processInstanceId);
         }
+        if (parameters == null) {
+            parameters = new HashMap<>();
+        }
+        parameters.put(ENTRY_POINT_VAR_NAME, caseDefinitionId);
+        
         CaseEventSupport caseEventSupport = getCaseEventSupport(context);
         caseEventSupport.fireBeforeDynamicProcessAdded(caseId, processInstanceId, processId, parameters);
         

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/AddDynamicProcessToStageCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/AddDynamicProcessToStageCommand.java
@@ -27,6 +27,7 @@ import org.kie.api.runtime.KieSession;
 import org.kie.api.runtime.process.ProcessInstance;
 import org.kie.api.runtime.Context;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,13 +42,17 @@ public class AddDynamicProcessToStageCommand extends CaseCommand<Long> {
     private String stageId;
     private long processInstanceId;
     private Map<String, Object> parameters;
+
+    private String caseDefinitionId;
     
-    public AddDynamicProcessToStageCommand(String caseId, Long processInstanceId, String stageId, String processId, Map<String, Object> parameters) {        
+    public AddDynamicProcessToStageCommand(String caseId, Long processInstanceId, String stageId, String processId, Map<String, Object> parameters, String caseDefinitionId) {        
         this.caseId = caseId;
         this.processInstanceId = processInstanceId;
         this.stageId = stageId;
         this.processId = processId;
         this.parameters = parameters;
+
+        this.caseDefinitionId = caseDefinitionId;
         
         if (processInstanceId == null || processId == null || stageId == null) {
             throw new IllegalArgumentException("Mandatory parameters are missing - process instance id / process id / stage id");
@@ -62,6 +67,10 @@ public class AddDynamicProcessToStageCommand extends CaseCommand<Long> {
         if (processInstance == null) {
             throw new ProcessInstanceNotFoundException("No process instance found with id " + processInstanceId);
         }
+        if (parameters == null) {
+            parameters = new HashMap<>();
+        }
+        parameters.put(ENTRY_POINT_VAR_NAME, caseDefinitionId);
         
         DynamicNodeInstance dynamicContext = (DynamicNodeInstance) ((WorkflowProcessInstanceImpl) processInstance).getNodeInstances(true).stream()
                 .filter(ni -> (ni instanceof DynamicNodeInstance) && stageId.equals(ni.getNode().getMetaData().get("UniqueId")))

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/CaseCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/CaseCommand.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 public abstract class CaseCommand<T> implements ExecutableCommand<T> {
 
     private static final long serialVersionUID = 4116744986913465571L;
+    protected static final String ENTRY_POINT_VAR_NAME = "_EntryPoint_";
     
     private CaseEventSupport emptyCaseEventSupport = new CaseEventSupport(Collections.emptyList());
 

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/CaseCommentCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/CaseCommentCommand.java
@@ -46,19 +46,24 @@ public class CaseCommentCommand extends CaseCommand<Void> {
     private String commentId;
 
     private String updatedText;
+    
+    private String caseDefinitionId;
 
-    public CaseCommentCommand(String author, String comment) {
+    public CaseCommentCommand(String caseDefinitionId, String author, String comment) {
+        this.caseDefinitionId = caseDefinitionId;
         this.author = author;
         this.comment = comment;
         this.add = true;
     }
 
-    public CaseCommentCommand(String commentId) {
+    public CaseCommentCommand(String caseDefinitionId, String commentId) {
+        this.caseDefinitionId = caseDefinitionId;
         this.commentId = commentId;
         this.remove = true;
     }
 
-    public CaseCommentCommand(String commentId, String author, String updatedText) {
+    public CaseCommentCommand(String caseDefinitionId, String commentId, String author, String updatedText) {
+        this.caseDefinitionId = caseDefinitionId;
         this.commentId = commentId;
         this.author = author;
         this.updatedText = updatedText;
@@ -70,12 +75,12 @@ public class CaseCommentCommand extends CaseCommand<Void> {
     public Void execute(Context context) {
         KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
 
-        Collection<? extends Object> caseFiles = ksession.getObjects(new ClassObjectFilter(CaseFileInstance.class));
+        Collection<? extends Object> caseFiles = ksession.getEntryPoint(caseDefinitionId).getObjects(new ClassObjectFilter(CaseFileInstance.class));
         if (caseFiles.size() != 1) {
             throw new IllegalStateException("Not able to find distinct case file - found case files " + caseFiles.size());
         }
         CaseFileInstance caseFile = (CaseFileInstance) caseFiles.iterator().next();
-        FactHandle factHandle = ksession.getFactHandle(caseFile);
+        FactHandle factHandle = ksession.getEntryPoint(caseDefinitionId).getFactHandle(caseFile);
 
         CaseEventSupport caseEventSupport = getCaseEventSupport(context);
 
@@ -104,7 +109,7 @@ public class CaseCommentCommand extends CaseCommand<Void> {
             ((CaseFileInstanceImpl)caseFile).removeComment(toRemove);
             caseEventSupport.fireBeforeCaseCommentRemoved(caseFile.getCaseId(), toRemove);
         }
-        ksession.update(factHandle, caseFile);
+        ksession.getEntryPoint(caseDefinitionId).update(factHandle, caseFile);
         return null;
     }
 

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/ModifyRoleAssignmentCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/ModifyRoleAssignmentCommand.java
@@ -39,7 +39,10 @@ public class ModifyRoleAssignmentCommand extends CaseCommand<Void> {
     private OrganizationalEntity entity;
     private boolean add;
     
-    public ModifyRoleAssignmentCommand(String roleName, OrganizationalEntity entity, boolean add) {
+    private String caseDefinitionId;
+    
+    public ModifyRoleAssignmentCommand(String caseDefinitionId, String roleName, OrganizationalEntity entity, boolean add) {
+        this.caseDefinitionId = caseDefinitionId;
         this.roleName = roleName;
         this.entity = entity;
         this.add = add;
@@ -49,12 +52,12 @@ public class ModifyRoleAssignmentCommand extends CaseCommand<Void> {
     public Void execute(Context context) {
         KieSession ksession = ((RegistryContext) context).lookup( KieSession.class );
         
-        Collection<? extends Object> caseFiles = ksession.getObjects(new ClassObjectFilter(CaseFileInstance.class));
+        Collection<? extends Object> caseFiles = ksession.getEntryPoint(caseDefinitionId).getObjects(new ClassObjectFilter(CaseFileInstance.class));
         if (caseFiles.size() != 1) {
             throw new IllegalStateException("Not able to find distinct case file - found case files " + caseFiles.size());
         }
         CaseFileInstance caseFile = (CaseFileInstance) caseFiles.iterator().next();
-        FactHandle factHandle = ksession.getFactHandle(caseFile);
+        FactHandle factHandle = ksession.getEntryPoint(caseDefinitionId).getFactHandle(caseFile);
         
         CaseEventSupport caseEventSupport = getCaseEventSupport(context);
         
@@ -68,7 +71,7 @@ public class ModifyRoleAssignmentCommand extends CaseCommand<Void> {
             caseEventSupport.fireAfterCaseRoleAssignmentRemoved(caseFile.getCaseId(), roleName, entity);
         }
         
-        ksession.update(factHandle, caseFile);
+        ksession.getEntryPoint(caseDefinitionId).update(factHandle, caseFile);
         return null;
     }
 

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/StartCaseCommand.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/command/StartCaseCommand.java
@@ -74,13 +74,14 @@ public class StartCaseCommand extends CaseCommand<Void> {
         caseEventSupport.fireBeforeCaseStarted(caseId, deploymentId, caseDefinitionId, caseFile);
         
         logger.debug("Inserting case file into working memory");
-        processService.execute(deploymentId, CaseContext.get(caseId), commandsFactory.newInsert(caseFile));
+        processService.execute(deploymentId, CaseContext.get(caseId), commandsFactory.newInsert(caseFile, "caseFile", false, caseDefinitionId));
         
         logger.debug("Starting process instance for case {} and case definition {}", caseId, caseDefinitionId);
         CorrelationKey correlationKey = correlationKeyFactory.newCorrelationKey(caseId);
         Map<String, Object> params = new HashMap<>();
         // set case id to allow it to use CaseContext when creating runtime engine
         params.put(EnvironmentName.CASE_ID, caseId);
+        params.put(ENTRY_POINT_VAR_NAME, caseDefinitionId);
         final long processInstanceId = processService.startProcess(deploymentId, caseDefinitionId, correlationKey, params);
         logger.debug("Case {} successfully started (process instance id {})", caseId, processInstanceId);
         

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/marshalling/CaseFileInstanceMarshallingStrategy.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/marshalling/CaseFileInstanceMarshallingStrategy.java
@@ -44,6 +44,7 @@ public class CaseFileInstanceMarshallingStrategy implements ObjectMarshallingStr
     private static final Logger logger = LoggerFactory.getLogger(CaseFileInstanceMarshallingStrategy.class);
     
     private static final String CASE_ID_KEY = "CaseId";
+    private static final String CASE_DEF_KEY = "CaseDefId";
     private static final String CASE_START_KEY = "CaseStart";
     private static final String CASE_END_KEY = "CaseEnd";
     private static final String CASE_REOPEN_KEY = "CaseReopen";
@@ -119,6 +120,7 @@ public class CaseFileInstanceMarshallingStrategy implements ObjectMarshallingStr
         CaseFileInstanceImpl caseFile = (CaseFileInstanceImpl) object;
         Map<String, Object> caseFileContent = new HashMap<>();
         caseFileContent.put(CASE_ID_KEY, caseFile.getCaseId());
+        caseFileContent.put(CASE_DEF_KEY, caseFile.getCaseDefinitionId());
         caseFileContent.put(CASE_START_KEY, caseFile.getCaseStartDate());
         caseFileContent.put(CASE_END_KEY, caseFile.getCaseEndDate());
         caseFileContent.put(CASE_REOPEN_KEY, caseFile.getCaseReopenDate());
@@ -162,6 +164,7 @@ public class CaseFileInstanceMarshallingStrategy implements ObjectMarshallingStr
         
         CaseFileInstanceImpl caseFileInstance = new CaseFileInstanceImpl();
         caseFileInstance.setCaseId((String)caseFileContent.get(CASE_ID_KEY));
+        caseFileInstance.setCaseDefinitionId((String)caseFileContent.get(CASE_DEF_KEY));
         caseFileInstance.setCaseStartDate((Date)caseFileContent.get(CASE_START_KEY));
         caseFileInstance.setCaseEndDate((Date)caseFileContent.get(CASE_END_KEY));
         caseFileInstance.setCaseReopenDate((Date)caseFileContent.get(CASE_REOPEN_KEY));

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/model/instance/CaseFileInstanceImpl.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/main/java/org/jbpm/casemgmt/impl/model/instance/CaseFileInstanceImpl.java
@@ -52,6 +52,7 @@ public class CaseFileInstanceImpl implements CaseFileInstance, CaseAssignment, S
     private Date caseStartDate;
     private Date caseEndDate;
     private Date caseReopenDate;
+    private String caseDefinitionId;
     
     private Map<String, Object> data = new HashMap<>();    
     private Map<String, CaseRoleInstance> roles = new HashMap<>();    
@@ -63,18 +64,21 @@ public class CaseFileInstanceImpl implements CaseFileInstance, CaseAssignment, S
         
     }
     
-    public CaseFileInstanceImpl(String caseId) {
+    public CaseFileInstanceImpl(String caseId, String caseDefinitionId) {
         this.caseId = caseId;
+        this.caseDefinitionId = caseDefinitionId;
         this.caseStartDate = new Date();
     }
     
-    public CaseFileInstanceImpl(Map<String, Object> data) {        
+    public CaseFileInstanceImpl(Map<String, Object> data, String caseDefinitionId) {        
         this.data = data;
+        this.caseDefinitionId = caseDefinitionId;
         this.caseStartDate = new Date();
     }
     
-    public CaseFileInstanceImpl(String caseId, Map<String, Object> data) {
+    public CaseFileInstanceImpl(String caseId, String caseDefinitionId, Map<String, Object> data) {
         this.caseId = caseId;
+        this.caseDefinitionId = caseDefinitionId;
         this.data = data;
         this.caseStartDate = new Date();
     }
@@ -293,6 +297,14 @@ public class CaseFileInstanceImpl implements CaseFileInstance, CaseAssignment, S
         } else if (!data.equals(other.data))
             return false;
         return true;
+    }
+
+    public String getCaseDefinitionId() {
+        return caseDefinitionId;
+    }
+
+    public void setCaseDefinitionId(String caseDefinitionId) {
+        this.caseDefinitionId = caseDefinitionId;
     }
 
 }

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseServiceImplTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/CaseServiceImplTest.java
@@ -101,6 +101,7 @@ public class CaseServiceImplTest extends AbstractCaseServicesBaseTest {
         processes.add("cases/UserStageAdhocCase.bpmn2");
         processes.add("cases/ScriptRoleAssignmentCase.bpmn2");
         processes.add("cases/NoStartNodeAdhocCase.bpmn2");
+        processes.add("cases/CaseFileConditionalEvent.bpmn2");
         // add processes that can be used by cases but are not cases themselves
         processes.add("processes/DataVerificationProcess.bpmn2");
         
@@ -224,7 +225,7 @@ public class CaseServiceImplTest extends AbstractCaseServicesBaseTest {
             
             Collection<VariableDesc> vars = runtimeDataService.getVariablesCurrentState(((CaseInstanceImpl)cInstance).getProcessInstanceId());
             assertNotNull(vars);
-            assertEquals(2, vars.size());
+            assertEquals(3, vars.size());
             Map<String, Object> mappedVars = vars.stream().collect(toMap(v-> v.getVariableId(), v -> v.getNewValue()));
             assertEquals("my first case", mappedVars.get("caseFile_name"));
             assertEquals(FIRST_CASE_ID, mappedVars.get("CaseId"));
@@ -1574,6 +1575,82 @@ public class CaseServiceImplTest extends AbstractCaseServicesBaseTest {
             activeStages = caseRuntimeDataService.getCaseInstanceStages(caseId, true, new QueryContext());
             assertNotNull(activeStages);
             assertEquals(0,  activeStages.size());
+            
+        } catch (Exception e) {
+            logger.error("Unexpected error {}", e.getMessage(), e);
+            fail("Unexpected exception " + e.getMessage());
+        } finally {
+            if (caseId != null) {
+                caseService.cancelCase(caseId);
+            }
+        }
+    }
+    
+    @Test
+    public void testStartCaseWithConditionalEvent() {
+        assertNotNull(deploymentService);        
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+        
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        
+        Map<String, Object> data = new HashMap<>();
+        data.put("Documents", new ArrayList<>());
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(), COND_CASE_P_ID, data);        
+        
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), COND_CASE_P_ID, caseFile);
+        assertNotNull(caseId);
+        assertEquals(FIRST_CASE_ID, caseId);
+        try {
+            CaseInstance cInstance = caseService.getCaseInstance(caseId);
+            assertNotNull(cInstance);
+            assertEquals(deploymentUnit.getIdentifier(), cInstance.getDeploymentId());
+            
+            caseService.cancelCase(caseId);            
+            try {
+                caseService.getCaseInstance(caseId);
+                fail("Case was aborted so it should not be found any more");
+            } catch (CaseNotFoundException e) {
+                // expected as it was aborted
+            }
+            caseId = null;
+        } catch (Exception e) {
+            logger.error("Unexpected error {}", e.getMessage(), e);
+            fail("Unexpected exception " + e.getMessage());
+        } finally {
+            if (caseId != null) {
+                caseService.cancelCase(caseId);
+            }
+        }
+    }
+    
+    @Test
+    public void testStartCaseWithConditionalEventCompleteCase() {
+        assertNotNull(deploymentService);        
+        DeploymentUnit deploymentUnit = new KModuleDeploymentUnit(GROUP_ID, ARTIFACT_ID, VERSION);
+        
+        deploymentService.deploy(deploymentUnit);
+        units.add(deploymentUnit);
+        
+        List<String> docs = new ArrayList<>();
+        docs.add("First doc");
+        
+        Map<String, Object> data = new HashMap<>();
+        data.put("Documents", docs);
+        CaseFileInstance caseFile = caseService.newCaseFileInstance(deploymentUnit.getIdentifier(), COND_CASE_P_ID, data);        
+        
+        String caseId = caseService.startCase(deploymentUnit.getIdentifier(), COND_CASE_P_ID, caseFile);
+        assertNotNull(caseId);
+        assertEquals(FIRST_CASE_ID, caseId);
+        try {
+            
+            try {
+                caseService.getCaseInstance(caseId);
+                fail("Case instance should already be completed");
+            } catch (CaseNotFoundException e) {
+                // case is already completed as the docs where given at the start
+                caseId = null;
+            }
             
         } catch (Exception e) {
             logger.error("Unexpected error {}", e.getMessage(), e);

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/util/AbstractCaseServicesBaseTest.java
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/java/org/jbpm/casemgmt/impl/util/AbstractCaseServicesBaseTest.java
@@ -119,6 +119,7 @@ public abstract class AbstractCaseServicesBaseTest {
     protected static final String USER_TASK_STAGE_AUTO_START_CASE_P_ID = "UserTaskWithStageCaseAutoStart";
     protected static final String USER_TASK_STAGE_ADHOC_CASE_P_ID = "UserStageAdhocCase";
     protected static final String NO_START_NODE_CASE_P_ID = "NoStartNodeAdhocCase";
+    protected static final String COND_CASE_P_ID = "CaseFileConditionalEvent";
 
     protected static final String SUBPROCESS_P_ID = "DataVerification";
 

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/CaseFileConditionalEvent.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/CaseFileConditionalEvent.bpmn2
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_kxEXANf8EeaWo9b-_Nq0ug" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" exporter="jBPM Designer" exporterVersion="6.2.0" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_caseFile_DocumentsItem" structureRef="java.util.List"/>
+  <bpmn2:process id="CaseFileConditionalEvent" drools:adHoc="true" drools:version="1.0" name="CaseFileCondition" isExecutable="true">
+    <bpmn2:extensionElements>
+      <drools:metaData name="customCaseIdPrefix">
+        <drools:metaValue><![CDATA[CASE]]></drools:metaValue>
+      </drools:metaData>
+    </bpmn2:extensionElements>
+    <bpmn2:property id="caseFile_Documents" itemSubjectRef="_caseFile_DocumentsItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:selectable="true" color:background-color="#9acd32" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:outgoing>_2A1C5AEA-9261-44CC-82A5-5FCFF33C810D</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:intermediateCatchEvent id="_5EF641B7-63AD-44F1-97B0-0DC65EEED838" drools:selectable="true" drools:boundaryca="true" color:background-color="#f5deb3" color:border-color="#a0522d" color:color="#000000" name="Case File Condition">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Case File Condition]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_2A1C5AEA-9261-44CC-82A5-5FCFF33C810D</bpmn2:incoming>
+      <bpmn2:outgoing>_F52202C2-7F79-45E6-A83E-F0B9EAE664B2</bpmn2:outgoing>
+      <bpmn2:conditionalEventDefinition id="_kxEXAdf8EeaWo9b-_Nq0ug">
+        <bpmn2:condition xsi:type="bpmn2:tFormalExpression" id="_kxEXAtf8EeaWo9b-_Nq0ug" language="http://www.jboss.org/drools/rule"><![CDATA[org.kie.api.runtime.process.CaseData(((java.util.List)data.get("Documents")).size() > 0)]]></bpmn2:condition>
+      </bpmn2:conditionalEventDefinition>
+    </bpmn2:intermediateCatchEvent>
+    <bpmn2:scriptTask id="_90EF67EF-7D65-48C4-82BB-004E0D99BEC5" drools:selectable="true" color:background-color="#fafad2" color:border-color="#000000" color:color="#000000" name="Hello" scriptFormat="http://www.java.com/java">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[Hello]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_F52202C2-7F79-45E6-A83E-F0B9EAE664B2</bpmn2:incoming>
+      <bpmn2:outgoing>_3B82D99D-97CA-4FCF-BDD1-22AECB52ACA7</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Hello");]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_F52202C2-7F79-45E6-A83E-F0B9EAE664B2" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_5EF641B7-63AD-44F1-97B0-0DC65EEED838" targetRef="_90EF67EF-7D65-48C4-82BB-004E0D99BEC5"/>
+    <bpmn2:sequenceFlow id="_2A1C5AEA-9261-44CC-82A5-5FCFF33C810D" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_5EF641B7-63AD-44F1-97B0-0DC65EEED838"/>
+    <bpmn2:sequenceFlow id="_3B82D99D-97CA-4FCF-BDD1-22AECB52ACA7" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_90EF67EF-7D65-48C4-82BB-004E0D99BEC5" targetRef="_DF6AFC74-C7A2-4B3B-A944-BF80C4B7896C"/>
+    <bpmn2:endEvent id="_DF6AFC74-C7A2-4B3B-A944-BF80C4B7896C" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">
+      <bpmn2:extensionElements>
+        <drools:metaData name="elementname">
+          <drools:metaValue><![CDATA[]]></drools:metaValue>
+        </drools:metaData>
+      </bpmn2:extensionElements>
+      <bpmn2:incoming>_3B82D99D-97CA-4FCF-BDD1-22AECB52ACA7</bpmn2:incoming>
+      <bpmn2:terminateEventDefinition id="_kxEXA9f8EeaWo9b-_Nq0ug"/>
+    </bpmn2:endEvent>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_kxEXBNf8EeaWo9b-_Nq0ug">
+    <bpmndi:BPMNPlane id="_kxEXBdf8EeaWo9b-_Nq0ug" bpmnElement="CaseReproducer.CaseFileCondition">
+      <bpmndi:BPMNShape id="_kxEXBtf8EeaWo9b-_Nq0ug" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="180.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_kxEXB9f8EeaWo9b-_Nq0ug" bpmnElement="_5EF641B7-63AD-44F1-97B0-0DC65EEED838">
+        <dc:Bounds height="30.0" width="30.0" x="270.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_kxEXCNf8EeaWo9b-_Nq0ug" bpmnElement="_90EF67EF-7D65-48C4-82BB-004E0D99BEC5">
+        <dc:Bounds height="80.0" width="100.0" x="345.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_kxEXCdf8EeaWo9b-_Nq0ug" bpmnElement="_DF6AFC74-C7A2-4B3B-A944-BF80C4B7896C">
+        <dc:Bounds height="28.0" width="28.0" x="490.0" y="166.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_kxEXCtf8EeaWo9b-_Nq0ug" bpmnElement="_F52202C2-7F79-45E6-A83E-F0B9EAE664B2" sourceElement="_kxEXB9f8EeaWo9b-_Nq0ug" targetElement="_kxEXCNf8EeaWo9b-_Nq0ug">
+        <di:waypoint xsi:type="dc:Point" x="285.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="395.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_kxEXC9f8EeaWo9b-_Nq0ug" bpmnElement="_2A1C5AEA-9261-44CC-82A5-5FCFF33C810D" sourceElement="_kxEXBtf8EeaWo9b-_Nq0ug" targetElement="_kxEXB9f8EeaWo9b-_Nq0ug">
+        <di:waypoint xsi:type="dc:Point" x="195.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="285.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_kxEXDNf8EeaWo9b-_Nq0ug" bpmnElement="_3B82D99D-97CA-4FCF-BDD1-22AECB52ACA7" sourceElement="_kxEXCNf8EeaWo9b-_Nq0ug" targetElement="_kxEXCdf8EeaWo9b-_Nq0ug">
+        <di:waypoint xsi:type="dc:Point" x="395.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="504.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_kxEXDdf8EeaWo9b-_Nq0ug" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5EF641B7-63AD-44F1-97B0-0DC65EEED838" id="_kxEXDtf8EeaWo9b-_Nq0ug">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_2A1C5AEA-9261-44CC-82A5-5FCFF33C810D" id="_kxEXD9f8EeaWo9b-_Nq0ug">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_90EF67EF-7D65-48C4-82BB-004E0D99BEC5" id="_kxEXENf8EeaWo9b-_Nq0ug">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DF6AFC74-C7A2-4B3B-A944-BF80C4B7896C" id="_kxEXEdf8EeaWo9b-_Nq0ug">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_kxEXEtf8EeaWo9b-_Nq0ug">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_F52202C2-7F79-45E6-A83E-F0B9EAE664B2" id="_kxEXE9f8EeaWo9b-_Nq0ug">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_3B82D99D-97CA-4FCF-BDD1-22AECB52ACA7" id="_kxEXFNf8EeaWo9b-_Nq0ug">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_kxEXANf8EeaWo9b-_Nq0ug</bpmn2:source>
+    <bpmn2:target>_kxEXANf8EeaWo9b-_Nq0ug</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/UserTaskWithStageCase.bpmn2
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/cases/UserTaskWithStageCase.bpmn2
@@ -88,7 +88,7 @@
       </bpmn2:userTask>
       <bpmn2:sequenceFlow id="_59C8EAE4-4B58-4002-8236-5EBA5BB1F423" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_88CD21B4-11DD-41DA-8248-8D7CBC55AB27" targetRef="_D0BEE540-1820-47EB-A88C-D7374BB1562F"/>
       <bpmn2:sequenceFlow id="_ADB2DD52-3A32-4D6E-AD90-72528A37DFBE" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="_D0BEE540-1820-47EB-A88C-D7374BB1562F" targetRef="_6FED15B1-42A9-46CB-8804-73255F56D4EB"/>
-      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_jvALFlAKEeafR5ATvnlHeA" language="http://www.jboss.org/drools/rule"><![CDATA[org.kie.api.runtime.process.CaseData(data.get("dataComplete") == true);]]></bpmn2:completionCondition>
+      <bpmn2:completionCondition xsi:type="bpmn2:tFormalExpression" id="_jvALFlAKEeafR5ATvnlHeA" language="http://www.jboss.org/drools/rule"><![CDATA[org.kie.api.runtime.process.CaseData(data.get("dataComplete") == true)]]></bpmn2:completionCondition>
     </bpmn2:adHocSubProcess>
     <bpmn2:sequenceFlow id="_67625E63-4A05-4B40-8F4A-5823A0130242" drools:selectable="true" color:background-color="#000000" color:border-color="#000000" color:color="#000000" sourceRef="processStartEvent" targetRef="_098AE30C-D548-4082-9F62-26FED6521539"/>
     <bpmn2:endEvent id="_7780E1CE-2105-4624-9A33-246862D633C7" drools:selectable="true" color:background-color="#ff6347" color:border-color="#000000" color:color="#000000" name="">

--- a/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/org/jbpm/casemgmt/demo/insurance/insurance-rules.drl
+++ b/jbpm-case-mgmt/jbpm-case-mgmt-impl/src/test/resources/org/jbpm/casemgmt/demo/insurance/insurance-rules.drl
@@ -6,7 +6,7 @@ import org.jbpm.casemgmt.demo.insurance.ClaimReport;
 rule "classify-claim" ruleflow-group "claims"
 
 when 
-    $caseData : CaseData()
+    $caseData : CaseData() from entry-point "insurance-claims.CarInsuranceClaimCase" 
     $claim : ClaimReport( ) from $caseData.getData("claimReport")      
 then 
     System.out.println("Classified claim " + $claim);

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SubProcessNodeInstance.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/instance/node/SubProcessNodeInstance.java
@@ -75,6 +75,8 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
     private static final long serialVersionUID = 510l;
     private static final Logger logger = LoggerFactory.getLogger(SubProcessNodeInstance.class);
     
+    private static final String ENTRY_POINT_VAR_NAME = "_EntryPoint_";
+    
     // NOTE: ContetxInstances are not persisted as current functionality (exception scope) does not require it
     private Map<String, ContextInstance> contextInstances = new HashMap<String, ContextInstance>();
     private Map<String, List<ContextInstance>> subContextInstances = new HashMap<String, List<ContextInstance>>();
@@ -192,6 +194,7 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
                 String caseId = (String) kruntime.getEnvironment().get(EnvironmentName.CASE_ID);
                 if (caseId != null) {
                     context = CaseContext.get(caseId);
+                    parameters.put(EnvironmentName.CASE_ID, caseId);
                 }
                 
                 RuntimeEngine runtime = manager.getRuntimeEngine(context);
@@ -200,6 +203,9 @@ public class SubProcessNodeInstance extends StateBasedNodeInstance implements Ev
             if (getSubProcessNode().getMetaData("MICollectionInput") != null) {
                 // remove foreach input variable to avoid problems when running in variable strict mode
                 parameters.remove(getSubProcessNode().getMetaData("MICollectionInput"));
+            }
+            if (getVariable(ENTRY_POINT_VAR_NAME) != null) {
+                parameters.put(ENTRY_POINT_VAR_NAME, getVariable(ENTRY_POINT_VAR_NAME));
             }
 
             ProcessInstance processInstance = null;


### PR DESCRIPTION
depends on https://github.com/droolsjbpm/drools/pull/1060

@krisv here is a change to use entry points for case file that is named same as case definition (ad hoc process id) that way case definitions conditions are isolated to its own type/definition so they don't interfere.

The problem here is that all conditions (drools rules) are compiled into kbase and shared globally for all process definitions. This is not really a case mgmt issue but overall problem though it will be mostly visible in cases where conditions will usually refer to CaseData (aka CaseFile).

To be able to support layered case instances - case definitions + subprocesses to access easily same file the entry point (process id of the case def) is stored as process variable. That way it is always given to child processes and can be used to look up the right entry point to find case file. 

What do you think? I couldn't find any other applicable solution than this... so open for any ideas.

Only other alternative is to put the requirement on end users to keep in mind that when there are multiple case definitions with conditions (which most likely be rather normal case) then conditions must be distinct like using case definition id as part of the conditions. Not always possible and easy to mis... especially that it can't be caught on compile time but on runtime.