### PR TITLE
Fix failing test after Weld 2.4.1.Final upgrade

### DIFF
--- a/jbpm-services/jbpm-services-cdi/pom.xml
+++ b/jbpm-services/jbpm-services-cdi/pom.xml
@@ -104,7 +104,6 @@
       <artifactId>dashbuilder-dataset-api</artifactId>
     </dependency>
 
-    
     <!-- test -->
     <dependency>
       <groupId>org.jboss.weld</groupId>
@@ -132,11 +131,23 @@
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-entitymanager</artifactId>
       <scope>test</scope>
+       <exclusions>
+         <exclusion>
+           <groupId>org.apache.geronimo.specs</groupId>
+           <artifactId>geronimo-jta_1.1_spec</artifactId>
+         </exclusion>
+       </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.geronimo.specs</groupId>
+          <artifactId>geronimo-jta_1.1_spec</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>
@@ -175,7 +186,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <build>
     <plugins>  
       <plugin>

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceProducer.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceProducer.java
@@ -15,45 +15,34 @@
  */
 package org.jbpm.services.cdi.test.humantaskservice;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
-
-import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Produces;
-import javax.inject.Qualifier;
 
 import org.drools.core.impl.EnvironmentFactory;
 import org.drools.persistence.jta.JtaTransactionManager;
 import org.jbpm.services.cdi.producer.HumanTaskServiceProducer;
 import org.jbpm.services.task.HumanTaskConfigurator;
 import org.jbpm.services.task.impl.command.CommandBasedTaskService;
-import org.jbpm.services.task.persistence.JPATaskPersistenceContextManager;
 import org.kie.api.runtime.Environment;
 import org.kie.api.runtime.EnvironmentName;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 
-/**
- *
- *
- */
 public class CustomHumanTaskServiceProducer extends HumanTaskServiceProducer {
 
     @Produces
     @CustomHumanTaskService
     @Override
     public CommandBasedTaskService produceTaskService() {
-        return super.produceTaskService();
+        CommandBasedTaskService taskServiceMock = Mockito.mock(CommandBasedTaskService.class);
+        Mockito.when(taskServiceMock.execute(Mockito.any())).thenAnswer((InvocationOnMock invocation) -> {
+            throw new CustomTaskServiceInUse();
+        });
+        return taskServiceMock;
     }
 
     @Override
     protected void configureHumanTaskConfigurator(HumanTaskConfigurator configurator) {
         Environment environment = EnvironmentFactory.newEnvironment();
-        environment.set(EnvironmentName.TASK_PERSISTENCE_CONTEXT_MANAGER, new CustomTaskPersistenceContextManager());
         environment.set(EnvironmentName.TRANSACTION_MANAGER, new CustomTransactionManager());
         super.configureHumanTaskConfigurator(configurator.environment(environment));
     }
@@ -65,21 +54,10 @@ public class CustomHumanTaskServiceProducer extends HumanTaskServiceProducer {
     }
 
 
-    public static class CustomTaskPersistenceContextManager extends JPATaskPersistenceContextManager {
-        public CustomTaskPersistenceContextManager() {
-            super(EnvironmentFactory.newEnvironment());
-        }
-
-        @Override
-        public void beginCommandScopedEntityManager() {
-            throw new CustomTaskPersistenceContextManagerInUse();
-        }
-    }
-
     /**
-     * Exception throw to show the CustomTaskPersistenceContextManager is in use.
+     * Exception throw to show the custom service task is in use.
      */
     @SuppressWarnings("serial")
-    public static class CustomTaskPersistenceContextManagerInUse extends RuntimeException {}
+    public static class CustomTaskServiceInUse extends RuntimeException {}
 
 }

--- a/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceTest.java
+++ b/jbpm-services/jbpm-services-cdi/src/test/java/org/jbpm/services/cdi/test/humantaskservice/CustomHumanTaskServiceTest.java
@@ -23,7 +23,7 @@ import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jbpm.kie.test.util.AbstractKieServicesBaseTest;
-import org.jbpm.services.cdi.test.humantaskservice.CustomHumanTaskServiceProducer.CustomTaskPersistenceContextManagerInUse;
+import org.jbpm.services.cdi.test.humantaskservice.CustomHumanTaskServiceProducer.CustomTaskServiceInUse;
 import org.jbpm.services.task.commands.TaskCommand;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -147,13 +147,12 @@ public class CustomHumanTaskServiceTest extends AbstractKieServicesBaseTest {
     }
 
     /**
-     * The CustomHumanTaskService is configured with a TaskPersistenceContextManager
-     * implementation that throws an exception to prove that the custom environment
-     * is in use.
+     * The CustomHumanTaskService is configured as a mock which throws an exception
+     * when the the execute() method is called.
      *
      * @throws Exception
      */
-    @Test(expected=CustomTaskPersistenceContextManagerInUse.class)
+    @Test(expected=CustomTaskServiceInUse.class)
     public void testCustomTaskService() throws Exception {
         customTaskService.execute(new TestCommand());
     }


### PR DESCRIPTION
Weld 2.4.1.Final behaves somewhat different and is initializing the beans
during discovery. That leads to a call
CustomTaskPersistenceContextManager#beginCommandScopedEntityManager
which throws the exception. The bean is thus not initialized and the CDI
container is not able to inject some members (as they were not
initialized and thus are not available for injection). Using the
CommandBasedTaskService mock should lead to a same result - we do assert
that the custom bean is being injected as the execute() methods throws
exception.

Needs to be merged together with https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/350.

@mswiderski could you please take a look? I am not sure I understood the intention of the test correctly, so the fix may have to be updated.