### PR TITLE
JBPM-5681 - DMN support for BusinessRuleTask

### DIFF
--- a/jbpm-bpmn2/pom.xml
+++ b/jbpm-bpmn2/pom.xml
@@ -65,6 +65,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+ 
     
     <!-- Test -->
     <dependency>
@@ -75,6 +76,11 @@
     <dependency>
       <groupId>xmlunit</groupId>
       <artifactId>xmlunit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-core</artifactId>
       <scope>test</scope>
     </dependency>
     

--- a/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
+++ b/jbpm-bpmn2/src/main/java/org/jbpm/bpmn2/xml/BusinessRuleTaskHandler.java
@@ -37,6 +37,9 @@ import org.xml.sax.SAXException;
 
 public class BusinessRuleTaskHandler extends AbstractNodeHandler {
 	
+    private static final String NAMESPACE_PROP = "namespace";
+    private static final String MODEL_PROP = "model";
+    private static final String DECISION_PROP = "decision";
 	private DataTransformerRegistry transformerRegistry = DataTransformerRegistry.get();
     
     protected Node createNode(Attributes attrs) {
@@ -56,6 +59,12 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
 		if (ruleFlowGroup != null) {
 			ruleSetNode.setRuleFlowGroup(ruleFlowGroup);
 		}
+		String language = element.getAttribute("implementation");
+		if (language == null || language.equalsIgnoreCase("##unspecified") || language.isEmpty()) {
+		    language = RuleSetNode.DRL_LANG;
+		}
+		ruleSetNode.setLanguage(language);
+		
 		org.w3c.dom.Node xmlNode = element.getFirstChild();
 		while (xmlNode != null) {
             String nodeName = xmlNode.getNodeName();
@@ -68,6 +77,9 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
             }
             xmlNode = xmlNode.getNextSibling();
         }
+		ruleSetNode.setNamespace((String) ruleSetNode.removeParameter(NAMESPACE_PROP));
+		ruleSetNode.setModel((String) ruleSetNode.removeParameter(MODEL_PROP));
+		ruleSetNode.setDecision((String) ruleSetNode.removeParameter(DECISION_PROP));
 		
         handleScript(ruleSetNode, element, "onEntry");
         handleScript(ruleSetNode, element, "onExit");
@@ -77,8 +89,11 @@ public class BusinessRuleTaskHandler extends AbstractNodeHandler {
 		RuleSetNode ruleSetNode = (RuleSetNode) node;
 		writeNode("businessRuleTask", ruleSetNode, xmlDump, metaDataType);
 		if (ruleSetNode.getRuleFlowGroup() != null) {
-			xmlDump.append("g:ruleFlowGroup=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(ruleSetNode.getRuleFlowGroup()) + "\" >" + EOL);
+			xmlDump.append("g:ruleFlowGroup=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(ruleSetNode.getRuleFlowGroup()) + "\" " + EOL);
 		}
+		
+        xmlDump.append(" implementation=\"" + XmlBPMNProcessDumper.replaceIllegalCharsAttribute(ruleSetNode.getLanguage()) + "\" >" + EOL);        
+		
 		writeExtensionElements(ruleSetNode, xmlDump);
 		writeIO(ruleSetNode, xmlDump);
 		endNode("businessRuleTask", xmlDump);

--- a/jbpm-bpmn2/src/test/resources/dmn/0020-vacation-days.dmn
+++ b/jbpm-bpmn2/src/test/resources/dmn/0020-vacation-days.dmn
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0020_vacation_days" name="0020-vacation-days"
+  namespace="https://www.drools.org/kie-dmn" xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+  xmlns:kie="https://www.drools.org/kie-dmn" xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+  <inputData id="i_Age" name="Age">
+    <variable name="Age" typeRef="feel:number" />
+  </inputData>
+
+  <inputData id="i_Years_of_Service" name="Years of Service">
+    <variable name="Years of Service" typeRef="feel:number" />
+  </inputData>
+
+  <decision name="Total Vacation Days" id="d_Total_Vacation_Days">
+    <variable name="Total Vacation Days" typeRef="feel:number" />
+    <informationRequirement>
+      <requiredDecision href="#d_Base_Vacation_Days" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#d_Extra_days_case_1" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#d_Extra_days_case_2" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredDecision href="#d_Extra_days_case_3" />
+    </informationRequirement>
+    <literalExpression>
+      <text>Base Vacation Days +
+        max( Extra days case 1, Extra days case 3 ) +
+        Extra days case 2
+      </text>
+    </literalExpression>
+  </decision>
+
+  <decision name="Extra days case 1" id="d_Extra_days_case_1">
+    <variable name="Extra days case 1" typeRef="feel:number" />
+    <informationRequirement>
+      <requiredInput href="#i_Age" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#i_Years_of_Service" />
+    </informationRequirement>
+    <decisionTable hitPolicy="COLLECT" aggregation="MAX">
+      <input id="d_Extra_days_case_1_dt_i_age" label="Age">
+        <inputExpression typeRef="feel:number">
+          <text>Age</text>
+        </inputExpression>
+      </input>
+      <input id="d_Extra_days_case_1_dt_i_years" label="Years of Service">
+        <inputExpression typeRef="feel:number">
+          <text>Years of Service</text>
+        </inputExpression>
+      </input>
+      <output id="d_Extra_days_case_1_dt_o" label="Extra days">
+        <defaultOutputEntry>
+          <text>0</text>
+        </defaultOutputEntry>
+      </output>
+      <rule id="d_Extra_days_case_1_dt_r1">
+        <inputEntry id="d_Extra_days_case_1_dt_r1_i1">
+          <text>&lt;18,&gt;=60</text>
+        </inputEntry>
+        <inputEntry id="d_Extra_days_case_1_dt_r1_i2">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="d_Extra_days_case_1_dt_r1_o1">
+          <text>5</text>
+        </outputEntry>
+      </rule>
+      <rule id="d_Extra_days_case_1_dt_r2">
+        <inputEntry id="d_Extra_days_case_1_dt_r2_i1">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="d_Extra_days_case_1_dt_r2_i2">
+          <text>&gt;=30</text>
+        </inputEntry>
+        <outputEntry id="d_Extra_days_case_1_dt_r2_o1">
+          <text>5</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <decision name="Extra days case 2" id="d_Extra_days_case_2">
+    <variable name="Extra days case 2" typeRef="feel:number" />
+    <informationRequirement>
+      <requiredInput href="#i_Age" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#i_Years_of_Service" />
+    </informationRequirement>
+    <decisionTable hitPolicy="COLLECT" aggregation="MAX">
+      <input id="d_Extra_days_case_2_dt_i_age" label="Age">
+        <inputExpression typeRef="feel:number">
+          <text>Age</text>
+        </inputExpression>
+      </input>
+      <input id="d_Extra_days_case_2_dt_i_years" label="Years of Service">
+        <inputExpression typeRef="feel:number">
+          <text>Years of Service</text>
+        </inputExpression>
+      </input>
+      <output id="d_Extra_days_case_2_dt_o" label="Extra days">
+        <defaultOutputEntry>
+          <text>0</text>
+        </defaultOutputEntry>
+      </output>
+      <rule id="d_Extra_days_case_2_dt_r1">
+        <inputEntry id="d_Extra_days_case_2_dt_r1_i1">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="d_Extra_days_case_2_dt_r1_i2">
+          <text>&gt;=30</text>
+        </inputEntry>
+        <outputEntry id="d_Extra_days_case_2_dt_r1_o1">
+          <text>3</text>
+        </outputEntry>
+      </rule>
+      <rule id="d_Extra_days_case_2_dt_r2">
+        <inputEntry id="d_Extra_days_case_2_dt_r2_i1">
+          <text>&gt;=60</text>
+        </inputEntry>
+        <inputEntry id="d_Extra_days_case_2_dt_r2_i2">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="d_Extra_days_case_2_dt_r2_o1">
+          <text>3</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <decision name="Extra days case 3" id="d_Extra_days_case_3">
+    <variable name="Extra days case 3" typeRef="feel:number" />
+    <informationRequirement>
+      <requiredInput href="#i_Age" />
+    </informationRequirement>
+    <informationRequirement>
+      <requiredInput href="#i_Years_of_Service" />
+    </informationRequirement>
+    <decisionTable hitPolicy="COLLECT" aggregation="MAX">
+      <input id="d_Extra_days_case_3_dt_i_age" label="Age">
+        <inputExpression typeRef="feel:number">
+          <text>Age</text>
+        </inputExpression>
+      </input>
+      <input id="d_Extra_days_case_3_dt_i_years" label="Years of Service">
+        <inputExpression typeRef="feel:number">
+          <text>Years of Service</text>
+        </inputExpression>
+      </input>
+      <output id="d_Extra_days_case_3_dt_o" label="Extra days">
+        <defaultOutputEntry>
+          <text>0</text>
+        </defaultOutputEntry>
+      </output>
+      <rule id="d_Extra_days_case_3_dt_r1">
+        <inputEntry id="d_Extra_days_case_3_dt_r1_i1">
+          <text>-</text>
+        </inputEntry>
+        <inputEntry id="d_Extra_days_case_3_dt_r1_i2">
+          <text>[15..30)</text>
+        </inputEntry>
+        <outputEntry id="d_Extra_days_case_3_dt_r1_o1">
+          <text>2</text>
+        </outputEntry>
+      </rule>
+      <rule id="d_Extra_days_case_3_dt_r2">
+        <inputEntry id="d_Extra_days_case_3_dt_r2_i1">
+          <text>&gt;=45</text>
+        </inputEntry>
+        <inputEntry id="d_Extra_days_case_3_dt_r2_i2">
+          <text>-</text>
+        </inputEntry>
+        <outputEntry id="d_Extra_days_case_3_dt_r2_o1">
+          <text>2</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+
+  <decision id="d_Base_Vacation_Days" name="Base Vacation Days">
+    <variable name="Base Vacation Days" typeRef="feel:number" />
+    <literalExpression>
+      <text>22</text>
+    </literalExpression>
+  </decision>
+
+</definitions>

--- a/jbpm-bpmn2/src/test/resources/dmn/BPMN2-BusinessRuleTaskDMN.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/dmn/BPMN2-BusinessRuleTaskDMN.bpmn2
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_4stiAC9sEeOaG4BBbqOFwA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_ageItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_yearsOfServiceItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_vacationDaysItem" structureRef="java.math.BigDecimal"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInputItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInputItem" structureRef="java.lang.String"/>
+  <bpmn2:process id="BPMN2-BusinessRuleTask" drools:packageName="org.jbpm.bpmn2.objects" drools:version="1.0" name="withrules" isExecutable="true">
+    <bpmn2:property id="age" itemSubjectRef="_ageItem"/>
+    <bpmn2:property id="yearsOfService" itemSubjectRef="_yearsOfServiceItem"/>
+    <bpmn2:property id="vacationDays" itemSubjectRef="_vacationDaysItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:businessRuleTask id="_B837821D-9CA0-431E-8D4C-8065C3493CE7" name="Evaluate rule" implementation="http://www.jboss.org/drools/dmn">
+      <bpmn2:incoming>_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA</bpmn2:incoming>
+      <bpmn2:outgoing>_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_4suJEC9sEeOaG4BBbqOFwA">
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput" drools:dtype="java.lang.Integer" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInputItem" name="Age"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput" drools:dtype="java.lang.Integer" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInputItem" name="Years of Service"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInputItem" name="namespace"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInputItem" name="model"/>
+        <bpmn2:dataOutput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput" drools:dtype="java.math.BigDecimal" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysOutputItem" name="Total Vacation Days"/>
+        <bpmn2:inputSet id="_4suJES9sEeOaG4BBbqOFwA">
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_4suJEi9sEeOaG4BBbqOFwA">
+          <bpmn2:dataOutputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_4suJEy9sEeOaG4BBbqOFwA">
+        <bpmn2:sourceRef>age</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_4suJEy9sEeOaG4BBbqOFwB">
+        <bpmn2:sourceRef>yearsOfService</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ2g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ1g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ1g"><![CDATA[https://www.drools.org/kie-dmn]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ1g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ3g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ5g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ3g"><![CDATA[0020-vacation-days]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ3g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_4suJFC9sEeOaG4BBbqOFwA">
+        <bpmn2:sourceRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>vacationDays</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:businessRuleTask>
+    <bpmn2:sequenceFlow id="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7"/>
+    <bpmn2:scriptTask id="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" drools:selectable="true" name="Printout" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10</bpmn2:incoming>
+      <bpmn2:outgoing>_00D2A1E8-F343-478F-B301-B11C551F1037</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Vacation days  " + vacationDays);]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7" targetRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F"/>
+    <bpmn2:endEvent id="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_00D2A1E8-F343-478F-B301-B11C551F1037</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_00D2A1E8-F343-478F-B301-B11C551F1037" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" targetRef="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_4suJFS9sEeOaG4BBbqOFwA">
+    <bpmndi:BPMNPlane id="_4suJFi9sEeOaG4BBbqOFwA" bpmnElement="BPMN2-BusinessRuleTask">
+      <bpmndi:BPMNShape id="_4suJFy9sEeOaG4BBbqOFwA" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_4suJGC9sEeOaG4BBbqOFwA" bpmnElement="_B837821D-9CA0-431E-8D4C-8065C3493CE7">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJGS9sEeOaG4BBbqOFwA" bpmnElement="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_4suJGi9sEeOaG4BBbqOFwA" bpmnElement="_93BD2C60-4B4B-4AF6-A393-B75C3999135F">
+        <dc:Bounds height="80.0" width="100.0" x="340.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJGy9sEeOaG4BBbqOFwA" bpmnElement="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_4suJHC9sEeOaG4BBbqOFwA" bpmnElement="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21">
+        <dc:Bounds height="28.0" width="28.0" x="481.0" y="162.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJHS9sEeOaG4BBbqOFwA" bpmnElement="_00D2A1E8-F343-478F-B301-B11C551F1037">
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="495.0" y="176.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_4suJHi9sEeOaG4BBbqOFwA" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7" id="_4suJHy9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" id="_4suwIC9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_00D2A1E8-F343-478F-B301-B11C551F1037" id="_4suwIS9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_4suwIi9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:WaitTime xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:WaitTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21" id="_4suwIy9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10" id="_4suwJC9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA" id="_4suwJS9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_4stiAC9sEeOaG4BBbqOFwA</bpmn2:source>
+    <bpmn2:target>_4stiAC9sEeOaG4BBbqOFwA</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-bpmn2/src/test/resources/dmn/BPMN2-BusinessRuleTaskDMNByDecisionName.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/dmn/BPMN2-BusinessRuleTaskDMNByDecisionName.bpmn2
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_4stiAC9sEeOaG4BBbqOFwA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_ageItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_yearsOfServiceItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_vacationDaysItem" structureRef="java.math.BigDecimal"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInputItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInputItem" structureRef="java.lang.String"/>
+  <bpmn2:process id="BPMN2-BusinessRuleTask" drools:packageName="org.jbpm.bpmn2.objects" drools:version="1.0" name="withrules" isExecutable="true">
+    <bpmn2:property id="age" itemSubjectRef="_ageItem"/>
+    <bpmn2:property id="yearsOfService" itemSubjectRef="_yearsOfServiceItem"/>
+    <bpmn2:property id="vacationDays" itemSubjectRef="_vacationDaysItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:businessRuleTask id="_B837821D-9CA0-431E-8D4C-8065C3493CE7" name="Evaluate rule" implementation="http://www.jboss.org/drools/dmn">
+      <bpmn2:incoming>_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA</bpmn2:incoming>
+      <bpmn2:outgoing>_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_4suJEC9sEeOaG4BBbqOFwA">
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput" drools:dtype="java.lang.Integer" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInputItem" name="Age"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput" drools:dtype="java.lang.Integer" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInputItem" name="Years of Service"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInputItem" name="namespace"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInputItem" name="model"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_decisionInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_decisionInputItem" name="decision"/>
+        <bpmn2:dataOutput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput" drools:dtype="java.math.BigDecimal" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysOutputItem" name="Extra days case 1"/>
+        <bpmn2:inputSet id="_4suJES9sEeOaG4BBbqOFwA">
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_decisionInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_4suJEi9sEeOaG4BBbqOFwA">
+          <bpmn2:dataOutputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_4suJEy9sEeOaG4BBbqOFwA">
+        <bpmn2:sourceRef>age</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_4suJEy9sEeOaG4BBbqOFwB">
+        <bpmn2:sourceRef>yearsOfService</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ2g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ1g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ1g"><![CDATA[https://www.drools.org/kie-dmn]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ1g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ3g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ5g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ3g"><![CDATA[0020-vacation-days]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ3g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ7g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_decisionInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ8g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ9g"><![CDATA[Extra days case 1]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ9g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_decisionInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_4suJFC9sEeOaG4BBbqOFwA">
+        <bpmn2:sourceRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>vacationDays</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:businessRuleTask>
+    <bpmn2:sequenceFlow id="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7"/>
+    <bpmn2:scriptTask id="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" drools:selectable="true" name="Printout" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10</bpmn2:incoming>
+      <bpmn2:outgoing>_00D2A1E8-F343-478F-B301-B11C551F1037</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Vacation days  " + vacationDays);]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7" targetRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F"/>
+    <bpmn2:endEvent id="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_00D2A1E8-F343-478F-B301-B11C551F1037</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_00D2A1E8-F343-478F-B301-B11C551F1037" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" targetRef="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_4suJFS9sEeOaG4BBbqOFwA">
+    <bpmndi:BPMNPlane id="_4suJFi9sEeOaG4BBbqOFwA" bpmnElement="BPMN2-BusinessRuleTask">
+      <bpmndi:BPMNShape id="_4suJFy9sEeOaG4BBbqOFwA" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_4suJGC9sEeOaG4BBbqOFwA" bpmnElement="_B837821D-9CA0-431E-8D4C-8065C3493CE7">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJGS9sEeOaG4BBbqOFwA" bpmnElement="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_4suJGi9sEeOaG4BBbqOFwA" bpmnElement="_93BD2C60-4B4B-4AF6-A393-B75C3999135F">
+        <dc:Bounds height="80.0" width="100.0" x="340.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJGy9sEeOaG4BBbqOFwA" bpmnElement="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_4suJHC9sEeOaG4BBbqOFwA" bpmnElement="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21">
+        <dc:Bounds height="28.0" width="28.0" x="481.0" y="162.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJHS9sEeOaG4BBbqOFwA" bpmnElement="_00D2A1E8-F343-478F-B301-B11C551F1037">
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="495.0" y="176.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_4suJHi9sEeOaG4BBbqOFwA" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7" id="_4suJHy9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" id="_4suwIC9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_00D2A1E8-F343-478F-B301-B11C551F1037" id="_4suwIS9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_4suwIi9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:WaitTime xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:WaitTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21" id="_4suwIy9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10" id="_4suwJC9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA" id="_4suwJS9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_4stiAC9sEeOaG4BBbqOFwA</bpmn2:source>
+    <bpmn2:target>_4stiAC9sEeOaG4BBbqOFwA</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-bpmn2/src/test/resources/dmn/BPMN2-BusinessRuleTaskDMNMultipleDecisionsOutput.bpmn2
+++ b/jbpm-bpmn2/src/test/resources/dmn/BPMN2-BusinessRuleTaskDMNMultipleDecisionsOutput.bpmn2
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/bpmn20" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_4stiAC9sEeOaG4BBbqOFwA" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd" expressionLanguage="http://www.mvel.org/2.0" targetNamespace="http://www.omg.org/bpmn20" typeLanguage="http://www.java.com/javaTypes">
+  <bpmn2:itemDefinition id="_ageItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_yearsOfServiceItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="_vacationDaysItem" structureRef="java.math.BigDecimal"/>
+  <bpmn2:itemDefinition id="_extraDaysItem" structureRef="java.math.BigDecimal"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysOutputItem" structureRef="Integer"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInputItem" structureRef="java.lang.String"/>
+  <bpmn2:itemDefinition id="__B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInputItem" structureRef="java.lang.String"/>
+  <bpmn2:process id="BPMN2-BusinessRuleTask" drools:packageName="org.jbpm.bpmn2.objects" drools:version="1.0" name="withrules" isExecutable="true">
+    <bpmn2:property id="age" itemSubjectRef="_ageItem"/>
+    <bpmn2:property id="yearsOfService" itemSubjectRef="_yearsOfServiceItem"/>
+    <bpmn2:property id="vacationDays" itemSubjectRef="_vacationDaysItem"/>
+    <bpmn2:property id="extraDays" itemSubjectRef="_extraDaysItem"/>
+    <bpmn2:startEvent id="processStartEvent" drools:bgcolor="#9acd32" drools:selectable="true" name="">
+      <bpmn2:outgoing>_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA</bpmn2:outgoing>
+    </bpmn2:startEvent>
+    <bpmn2:businessRuleTask id="_B837821D-9CA0-431E-8D4C-8065C3493CE7" name="Evaluate rule" implementation="http://www.jboss.org/drools/dmn">
+      <bpmn2:incoming>_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA</bpmn2:incoming>
+      <bpmn2:outgoing>_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10</bpmn2:outgoing>
+      <bpmn2:ioSpecification id="_4suJEC9sEeOaG4BBbqOFwA">
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput" drools:dtype="java.lang.Integer" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInputItem" name="Age"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput" drools:dtype="java.lang.Integer" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInputItem" name="Years of Service"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInputItem" name="namespace"/>
+        <bpmn2:dataInput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput" drools:dtype="java.lang.String" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInputItem" name="model"/>
+        <bpmn2:dataOutput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput" drools:dtype="java.math.BigDecimal" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysOutputItem" name="Total Vacation Days"/>
+        <bpmn2:dataOutput id="_B837821D-9CA0-431E-8D4C-8065C3493CE7_extraDaysoutOutput" drools:dtype="java.math.BigDecimal" itemSubjectRef="__B837821D-9CA0-431E-8D4C-8065C3493CE7_extraDaysOutputItem" name="Extra days case 1"/>
+        <bpmn2:inputSet id="_4suJES9sEeOaG4BBbqOFwA">
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:dataInputRefs>
+          <bpmn2:dataInputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:dataInputRefs>
+        </bpmn2:inputSet>
+        <bpmn2:outputSet id="_4suJEi9sEeOaG4BBbqOFwA">
+          <bpmn2:dataOutputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput</bpmn2:dataOutputRefs>
+          <bpmn2:dataOutputRefs>_B837821D-9CA0-431E-8D4C-8065C3493CE7_extraDaysoutOutput</bpmn2:dataOutputRefs>
+        </bpmn2:outputSet>
+      </bpmn2:ioSpecification>
+      <bpmn2:dataInputAssociation id="_4suJEy9sEeOaG4BBbqOFwA">
+        <bpmn2:sourceRef>age</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_ageinInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_4suJEy9sEeOaG4BBbqOFwB">
+        <bpmn2:sourceRef>yearsOfService</bpmn2:sourceRef>
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_yearsOfServiceinInput</bpmn2:targetRef>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ2g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ1g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ1g"><![CDATA[https://www.drools.org/kie-dmn]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ1g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_namespaceInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataInputAssociation id="_OJ4c8mYDEeavbo3IsNuQ3g">
+        <bpmn2:targetRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:targetRef>
+        <bpmn2:assignment id="_OJ4c82YDEeavbo3IsNuQ5g">
+          <bpmn2:from xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9GYDEeavbo3IsNuQ3g"><![CDATA[0020-vacation-days]]></bpmn2:from>
+          <bpmn2:to xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="bpmn2:tFormalExpression" id="_OJ4c9WYDEeavbo3IsNuQ3g">_B837821D-9CA0-431E-8D4C-8065C3493CE7_modelInput</bpmn2:to>
+        </bpmn2:assignment>
+      </bpmn2:dataInputAssociation>
+      <bpmn2:dataOutputAssociation id="_4suJFC9sEeOaG4BBbqOFwA">
+        <bpmn2:sourceRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_vacationDaysoutOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>vacationDays</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+      <bpmn2:dataOutputAssociation id="_4suJFC9sEeOaG4BBbqOFwB">
+        <bpmn2:sourceRef>_B837821D-9CA0-431E-8D4C-8065C3493CE7_extraDaysoutOutput</bpmn2:sourceRef>
+        <bpmn2:targetRef>extraDays</bpmn2:targetRef>
+      </bpmn2:dataOutputAssociation>
+    </bpmn2:businessRuleTask>
+    <bpmn2:sequenceFlow id="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA" drools:bgcolor="#000000" drools:selectable="true" sourceRef="processStartEvent" targetRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7"/>
+    <bpmn2:scriptTask id="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" drools:selectable="true" name="Printout" scriptFormat="http://www.java.com/java">
+      <bpmn2:incoming>_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10</bpmn2:incoming>
+      <bpmn2:outgoing>_00D2A1E8-F343-478F-B301-B11C551F1037</bpmn2:outgoing>
+      <bpmn2:script><![CDATA[System.out.println("Vacation days  " + vacationDays);]]></bpmn2:script>
+    </bpmn2:scriptTask>
+    <bpmn2:sequenceFlow id="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7" targetRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F"/>
+    <bpmn2:endEvent id="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21" drools:bgcolor="#ff6347" drools:selectable="true" name="">
+      <bpmn2:incoming>_00D2A1E8-F343-478F-B301-B11C551F1037</bpmn2:incoming>
+    </bpmn2:endEvent>
+    <bpmn2:sequenceFlow id="_00D2A1E8-F343-478F-B301-B11C551F1037" drools:bgcolor="#000000" drools:selectable="true" sourceRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" targetRef="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21"/>
+  </bpmn2:process>
+  <bpmndi:BPMNDiagram id="_4suJFS9sEeOaG4BBbqOFwA">
+    <bpmndi:BPMNPlane id="_4suJFi9sEeOaG4BBbqOFwA" bpmnElement="BPMN2-BusinessRuleTask">
+      <bpmndi:BPMNShape id="_4suJFy9sEeOaG4BBbqOFwA" bpmnElement="processStartEvent">
+        <dc:Bounds height="30.0" width="30.0" x="120.0" y="165.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_4suJGC9sEeOaG4BBbqOFwA" bpmnElement="_B837821D-9CA0-431E-8D4C-8065C3493CE7">
+        <dc:Bounds height="80.0" width="100.0" x="195.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJGS9sEeOaG4BBbqOFwA" bpmnElement="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA">
+        <di:waypoint xsi:type="dc:Point" x="135.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_4suJGi9sEeOaG4BBbqOFwA" bpmnElement="_93BD2C60-4B4B-4AF6-A393-B75C3999135F">
+        <dc:Bounds height="80.0" width="100.0" x="340.0" y="140.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJGy9sEeOaG4BBbqOFwA" bpmnElement="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10">
+        <di:waypoint xsi:type="dc:Point" x="245.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_4suJHC9sEeOaG4BBbqOFwA" bpmnElement="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21">
+        <dc:Bounds height="28.0" width="28.0" x="481.0" y="162.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_4suJHS9sEeOaG4BBbqOFwA" bpmnElement="_00D2A1E8-F343-478F-B301-B11C551F1037">
+        <di:waypoint xsi:type="dc:Point" x="390.0" y="180.0"/>
+        <di:waypoint xsi:type="dc:Point" x="495.0" y="176.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmn2:relationship id="_4suJHi9sEeOaG4BBbqOFwA" type="BPSimData">
+    <bpmn2:extensionElements>
+      <bpsim:BPSimData>
+        <bpsim:Scenario xsi:type="bpsim:Scenario" id="default" name="Simulationscenario">
+          <bpsim:ScenarioParameters xsi:type="bpsim:ScenarioParameters" baseTimeUnit="min"/>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_B837821D-9CA0-431E-8D4C-8065C3493CE7" id="_4suJHy9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_93BD2C60-4B4B-4AF6-A393-B75C3999135F" id="_4suwIC9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+            <bpsim:CostParameters xsi:type="bpsim:CostParameters">
+              <bpsim:UnitCost xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:UnitCost>
+            </bpsim:CostParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_00D2A1E8-F343-478F-B301-B11C551F1037" id="_4suwIS9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="processStartEvent" id="_4suwIi9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:WaitTime xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="0.0"/>
+              </bpsim:WaitTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_5D14605E-F34F-475C-A3A3-A3F3F09ACB21" id="_4suwIy9sEeOaG4BBbqOFwA">
+            <bpsim:TimeParameters xsi:type="bpsim:TimeParameters">
+              <bpsim:ProcessingTime xsi:type="bpsim:Parameter">
+                <bpsim:UniformDistribution max="10.0" min="5.0"/>
+              </bpsim:ProcessingTime>
+            </bpsim:TimeParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_CDF5A14A-D296-42A4-9EAF-2F0910A4BC10" id="_4suwJC9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+          <bpsim:ElementParameters xsi:type="bpsim:ElementParameters" elementRef="_DE49B781-CAB0-4C7E-81AE-1A4EA34648CA" id="_4suwJS9sEeOaG4BBbqOFwA">
+            <bpsim:ControlParameters xsi:type="bpsim:ControlParameters">
+              <bpsim:Probability xsi:type="bpsim:Parameter">
+                <bpsim:FloatingParameter value="100.0"/>
+              </bpsim:Probability>
+            </bpsim:ControlParameters>
+          </bpsim:ElementParameters>
+        </bpsim:Scenario>
+      </bpsim:BPSimData>
+    </bpmn2:extensionElements>
+    <bpmn2:source>_4stiAC9sEeOaG4BBbqOFwA</bpmn2:source>
+    <bpmn2:target>_4stiAC9sEeOaG4BBbqOFwA</bpmn2:target>
+  </bpmn2:relationship>
+</bpmn2:definitions>

--- a/jbpm-flow/pom.xml
+++ b/jbpm-flow/pom.xml
@@ -96,6 +96,28 @@
       <groupId>org.drools</groupId>
       <artifactId>drools-core</artifactId>
     </dependency>
+  
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-api</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>kie-dmn-model</artifactId>
+          <groupId>org.kie</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- TODO remove kie-dmn-core once api is moved to kie-dmn-api -->
+    <dependency>
+      <groupId>org.kie</groupId>
+      <artifactId>kie-dmn-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>kie-dmn-model</artifactId>
+          <groupId>org.kie</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
@@ -144,4 +166,5 @@
       </exclusions>
     </dependency>
   </dependencies>
+
 </project>

--- a/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
+++ b/jbpm-flow/src/main/java/org/jbpm/ruleflow/core/validation/RuleFlowProcessValidator.java
@@ -166,9 +166,24 @@ public class RuleFlowProcessValidator implements ProcessValidator {
                 if (ruleSetNode.getTo() == null && !acceptsNoOutgoingConnections(node)) {
                     addErrorMessage(process, node, errors, "RuleSet has no outgoing connection.");
                 }
-                final String ruleFlowGroup = ruleSetNode.getRuleFlowGroup();
-                if (ruleFlowGroup == null || "".equals(ruleFlowGroup)) {
-                    addErrorMessage(process, node, errors, "RuleSet has no ruleflow-group.");
+                final String language = ruleSetNode.getLanguage();
+                
+                if (RuleSetNode.DRL_LANG.equals(language)) {
+                    final String ruleFlowGroup = ruleSetNode.getRuleFlowGroup();
+                    if (ruleFlowGroup == null || "".equals(ruleFlowGroup)) {
+                        addErrorMessage(process, node, errors, "RuleSet (DRL) has no ruleflow-group.");
+                    }
+                } else if (RuleSetNode.DMN_LANG.equals(language)) { 
+                    final String namespace = ruleSetNode.getNamespace();
+                    if (namespace == null || "".equals(namespace)) {
+                        addErrorMessage(process, node, errors, "RuleSet (DMN) has no namespace.");
+                    }
+                    final String model = ruleSetNode.getModel();
+                    if (model == null || "".equals(model)) {
+                        addErrorMessage(process, node, errors, "RuleSet (DMN) has no model.");
+                    }
+                } else {
+                    addErrorMessage(process, node, errors, "Unsupported rule language '" + language + "'");
                 }
                 if (ruleSetNode.getTimers() != null) {
 	                for (Timer timer: ruleSetNode.getTimers().keySet()) {

--- a/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
+++ b/jbpm-flow/src/main/java/org/jbpm/workflow/core/node/RuleSetNode.java
@@ -31,8 +31,20 @@ import org.kie.api.definition.process.Connection;
 public class RuleSetNode extends StateBasedNode {
 
     private static final long serialVersionUID = 510l;
+    
+    public static final String DRL_LANG = "http://www.jboss.org/drools/rule";
+    public static final String DMN_LANG = "http://www.jboss.org/drools/dmn";
 
+    private String language = DRL_LANG;
+    
+    // drl related properties
     private String ruleFlowGroup;
+    
+    // dmn related properties
+    private String namespace;
+    private String model;
+    private String decision;
+    
     private List<DataAssociation> inMapping = new LinkedList<DataAssociation>();
     private List<DataAssociation> outMapping = new LinkedList<DataAssociation>();
     
@@ -44,6 +56,38 @@ public class RuleSetNode extends StateBasedNode {
 
     public String getRuleFlowGroup() {
         return this.ruleFlowGroup;
+    }
+    
+    public String getLanguage() {
+        return language;
+    }
+    
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+    
+    public String getNamespace() {
+        return namespace;
+    }
+    
+    public void setNamespace(String namespace) {
+        this.namespace = namespace;
+    }
+    
+    public String getModel() {
+        return model;
+    }
+    
+    public void setModel(String model) {
+        this.model = model;
+    }
+    
+    public String getDecision() {
+        return decision;
+    }
+    
+    public void setDecision(String decision) {
+        this.decision = decision;
     }
 
     public void validateAddIncomingConnection(final String type, final Connection connection) {
@@ -156,4 +200,11 @@ public class RuleSetNode extends StateBasedNode {
         return this.parameters.get(param);
     }
     
+    public Object removeParameter(String param) {
+        return this.parameters.remove(param);
+    }
+    
+    public boolean isDMN() {
+        return DMN_LANG.equals(language);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.kie</groupId>
+        <artifactId>kie-dmn-bom</artifactId>
+        <version>${version.org.kie}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
@etirelli @tarilabs @krisv guys, here comes support for DMN in Business Rule Task of BPMN2

Overall, it's based on data input to provide following parameters:
- namespace - required
- model name - required
- decision name - optional, if not given will call evaluate all

these parameters are provided as data input/data input associations. So it differs from the DRL based support which requires rule flow group and that is given as attribute (an jBPM specific). Though that providing there three new custom attributes was a bit too much. Moreover, this aligns with how we deal with user tasks so we keep it consistent. At parsing time these DMN parameters are removed from the data inputs so they will never be inserted into the DMN context as input data so it's clear data set.

The switch that enables use of DMN in business rule task is based on standard attribute of businessRuleTask - implementation. This attribute is optional and can have following values:
- if not given at all, jBPM assumes it's DRL 
- if set to ##unspecified jBPM assumes it's DRL
- if set to http://www.jboss.org/drools/rule jBPM uses DRL
- if set to http://www.jboss.org/drools/dmn jBPM uses DMN

Users can use data input to map process variables as input data to the decision where data input name should match the name in DMN. Similar, data output can be used to retrieve results from DMNResult by their names and map back to process variables.

This is till not to be merged as jbpm-flow (core module) depends on kie-dmn-core due tot he fact there is api embedded in it. So once the split of kie-dmn-core to api is done this should be refactored to make sure jBPM relies only on kie-dmn-api.