### PR TITLE
[GUVNOR-2889] rename 'kie-wb-distribution-wars-*.war' to 'kie-wb-*.war'

### DIFF
--- a/jbpm-installer/src/main/filtered-resources/lib/readme.txt
+++ b/jbpm-installer/src/main/filtered-resources/lib/readme.txt
@@ -21,6 +21,6 @@ jBPM:
   jbpm-${version.org.kie}-eclipse-all.zip
 
 KIE WB:
-  kie-wb-distribution-wars-${version.org.kie}-wildfly10.zip
+  kie-wb-${version.org.kie}-wildfly10.war
 
 

--- a/jbpm-installer/src/main/resources/build.properties
+++ b/jbpm-installer/src/main/resources/build.properties
@@ -25,13 +25,13 @@ jBPM.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirec
 # for example: 
 #<RELEASE>
 # for EAP7:
-#   jBPM.console.url=http://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/kie-wb-distribution-wars/${jBPM.version}/kie-wb-distribution-wars-${jBPM.version}-eap7.war
+#   jBPM.console.url=http://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/kie-wb/${jBPM.version}/kie-wb-${jBPM.version}-eap7.war
 # for WildFly10:
-#   jBPM.console.url=https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/kie-wb-distribution-wars/${jBPM.version}/kie-wb-distribution-wars-${jBPM.version}-wildfly10.war
+#   jBPM.console.url=https://repository.jboss.org/nexus/content/groups/public-jboss/org/kie/kie-wb/${jBPM.version}/kie-wb-${jBPM.version}-wildfly10.war
 # or:
 #<SNAPSHOT>
-#   jBPM.console.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-wb-distribution-wars&v=${jBPM.version}&e=war&c=wildfly10
-jBPM.console.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-wb-distribution-wars&v=${jBPM.version}&e=war&c=wildfly10
+#   jBPM.console.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-wb&v=${jBPM.version}&e=war&c=wildfly10
+jBPM.console.url=https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=kie-wb&v=${jBPM.version}&e=war&c=wildfly10
 
 # the version of KIE Server you want to use
 # and the associated URL you want to get it from


### PR DESCRIPTION
Needs to be merged together with:
https://github.com/droolsjbpm/droolsjbpm-build-bootstrap/pull/398
https://github.com/droolsjbpm/kie-wb-distributions/pull/469