### PR TITLE
Add DB driver to Failsafe plugin's classpath

### DIFF
--- a/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
+++ b/jbpm-container-test/jbpm-remote-ejb-test/jbpm-remote-ejb-test-suite/pom.xml
@@ -302,7 +302,7 @@
             </includes>
             <argLine>${failsafe.arg.line}</argLine>
             <additionalClasspathElements>
-              <additionalClasspathElement>${project.build.directory}/jdbc_driver.jar</additionalClasspathElement>
+              <additionalClasspathElement>${maven.jdbc.driver.jar}</additionalClasspathElement>
             </additionalClasspathElements>
             <systemPropertyVariables>
               <project.version>${project.version}</project.version>


### PR DESCRIPTION
...to enable tests on Sybase, as driver needs to be present on client's classpath due to BZ1281864